### PR TITLE
Encounter Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Configurable and Context Driven Project 1999 Log Parser with NCurses Interface for Linux
 
-![img](https://i.imgur.com/Kau1J6z.png)
+![img](https://i.imgur.com/MzLNgMN.png)
 
 > Best used with the [Linux EQ Launch Manager](https://gist.github.com/mgeitz/aa295061c51b26d53dd818d0ebb3e37a) to maintain reasonable log file size
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ You can control some parser settings using `/say` in-game.  This is better suite
 
 > Does not effect global mute
 
+`/say parser encounter` - Toggle encounter parsing
+
+`/say parser encounter clear` - Clear the encounter stack
+
+`/say parser encounter end` - Sometimes, your logs don't catch an encounter end.  Use this command to fix that!
+
+`/say parser hello`
+
+`/say parser who`
+
+`/say parser where`
+
+`/say parser what state`
+
 
 ## Custom Alerting
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ You should now see `~/.eqa/` with the following structure
 ```
 $HOME/.eqa
         ⎿ config.json
+        ⎿ data/
+        ⎿ encounters/
         ⎿ log/
           ⎿ debug/
         ⎿ sound/
@@ -43,11 +45,23 @@ Spot check these default paths generated in `config.json`
     "settings": {
         "paths": {
             "alert_log": "[$HOME/.eqa/]log/",
+            "data": "[$HOME/.eqa/]data/",
+            "encounter": "[$HOME/.eqa/]encounters/",
             "char_log": "[$HOME]/.wine/drive_c/Program Files/Sony/EverQuest/Logs/",
             "sound": "[$HOME/.eqa/]sound/",
             "tmp_sound": "/tmp/eqa/sound/"
         },
 ```
+
+If you would like encounter parses saved, update the `auto_save` setting in `config.json` to `true` as shown below
+```
+  "settings": {
+    "encounter_parsing": {
+      "auto_save": "true"
+    },
+  },
+```
+
 > Press `0` to reload your config or restart the program if any changes were made to the config
 
 
@@ -69,7 +83,7 @@ Spot check these default paths generated in `config.json`
   - r       : Toggle raid mode
   - d       : Toggle debug mode
   - e       : Toggle encounter parsing
-  - m       : Toggle audio mute
+  - m       : Toggle global audio mute
 
 #### Settings
   - up      : Cycle up in selection

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Spot check these default paths generated in `config.json`
   - c     : Clear event box
   - r     : Toggle raid mode
   - d     : Toggle debug mode
+  - e     : Toggle encounter parsing
   - m     : Toggle audio mute
 
 #### Settings
@@ -216,6 +217,24 @@ Alert for the item `Hand Made Backpack` when someone else `/auctions` it and is 
 - `false`: Play no sound when an alert is raised
 
 > Any other sound value will be spoken as the audio trigger for that line type
+
+#### The all Line Type
+
+This line type behaves the same as any specific line type configuration, but configuration here will be used against all log lines.
+
+For example, the below configuration will alert if the word `help` is found in any line while in a raid context, even if that line isn't matched to a type by the parser.
+
+```
+    "all": {
+      "alert": {
+        "help": raid
+      },
+      "reaction": "alert",
+      "sound": "help is needed"
+    },
+```
+
+This can be helpful if you would like to alert for something not yet matched by the parser, though your [contribution](CONTRIBUTING.md#pull-requests) to a new line type match in the parser would also be welcome!
 
 ### Zones
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ Spot check these default paths generated in `config.json`
   - up    : Cycle up in selection
   - down  : Cycle down in selection
   - right : Toggle selection on
-  - left  : Toggle selection off
-  - space : Cycle selection
 
 ### Say Controls
 

--- a/README.md
+++ b/README.md
@@ -56,24 +56,25 @@ Spot check these default paths generated in `config.json`
 ### Keyboard Controls
 
 #### Global
-  - 1      : Events
-  - 2      : State
-  - 3      : Settings
-  - 4      : Help
-  - 0     : Reload config
+  - 1       : Events
+  - 2       : State
+  - 3       : Parse
+  - 4       : Settings
+  - 0       : Reload config
   - q / esc : Quit
+  - h       : Help
 
 #### Events
-  - c     : Clear event box
-  - r     : Toggle raid mode
-  - d     : Toggle debug mode
-  - e     : Toggle encounter parsing
-  - m     : Toggle audio mute
+  - c       : Clear event box
+  - r       : Toggle raid mode
+  - d       : Toggle debug mode
+  - e       : Toggle encounter parsing
+  - m       : Toggle audio mute
 
 #### Settings
-  - up    : Cycle up in selection
-  - down  : Cycle down in selection
-  - right : Toggle selection on
+  - up      : Cycle up in selection
+  - down    : Cycle down in selection
+  - right   : Toggle selection on
 
 ### Say Controls
 

--- a/eqa/eqalert.py
+++ b/eqa/eqalert.py
@@ -61,6 +61,7 @@ def startup(base_path):
         config = eqa_config.read_config(base_path)
         log_path = config["settings"]["paths"]["alert_log"]
         data_path = config["settings"]["paths"]["data"]
+        encounter_path = config["settings"]["paths"]["encounter"]
         sound_path = config["settings"]["paths"]["sound"]
         tmp_sound_path = config["settings"]["paths"]["tmp_sound"]
         char_log_path = config["settings"]["paths"]["char_log"]
@@ -75,15 +76,20 @@ def startup(base_path):
         # Make the log directory
         if not os.path.exists(log_path):
             print("    - making a place for logs")
-            os.makedirs(base_path + "log/")
+            os.makedirs(log_path)
 
         # Set log file
         logging.basicConfig(filename=log_path + "eqalert.log", level=logging.INFO)
 
         # Make the debug directory
-        if not os.path.exists(base_path + "log/debug/"):
+        if not os.path.exists(log_path + "debug/"):
             print("    - making a place for optional debug logs")
-            os.makedirs(base_path + "log/debug/")
+            os.makedirs(log_path + "debug/")
+
+        # Make the encounter directory
+        if not os.path.exists(encounter_path):
+            print("    - making a place for encounter logs")
+            os.makedirs(encounter_path)
 
         # Make the sound directory
         if not os.path.exists(sound_path):

--- a/eqa/eqalert.py
+++ b/eqa/eqalert.py
@@ -288,21 +288,21 @@ def main():
 
     ### Thread 1
     process_sound_1 = threading.Thread(
-        target=eqa_sound.process, args=(config, sound_q, exit_flag, cfg_reload)
+        target=eqa_sound.process, args=(config, sound_q, exit_flag, cfg_reload, state)
     )
     process_sound_1.daemon = True
     process_sound_1.start()
 
     ### Thread 2
     process_sound_2 = threading.Thread(
-        target=eqa_sound.process, args=(config, sound_q, exit_flag, cfg_reload)
+        target=eqa_sound.process, args=(config, sound_q, exit_flag, cfg_reload, state)
     )
     process_sound_2.daemon = True
     process_sound_2.start()
 
     ### Thread 3
     process_sound_3 = threading.Thread(
-        target=eqa_sound.process, args=(config, sound_q, exit_flag, cfg_reload)
+        target=eqa_sound.process, args=(config, sound_q, exit_flag, cfg_reload, state)
     )
     process_sound_3.daemon = True
     process_sound_3.start()
@@ -627,7 +627,7 @@ def main():
                         ##### Thread 1
                         process_sound_1 = threading.Thread(
                             target=eqa_sound.process,
-                            args=(config, sound_q, exit_flag, cfg_reload),
+                            args=(config, sound_q, exit_flag, cfg_reload, state),
                         )
                         process_sound_1.daemon = True
                         process_sound_1.start()
@@ -635,7 +635,7 @@ def main():
                         ##### Thread 2
                         process_sound_2 = threading.Thread(
                             target=eqa_sound.process,
-                            args=(config, sound_q, exit_flag, cfg_reload),
+                            args=(config, sound_q, exit_flag, cfg_reload, state),
                         )
                         process_sound_2.daemon = True
                         process_sound_2.start()
@@ -643,7 +643,7 @@ def main():
                         ##### Thread 3
                         process_sound_3 = threading.Thread(
                             target=eqa_sound.process,
-                            args=(config, sound_q, exit_flag, cfg_reload),
+                            args=(config, sound_q, exit_flag, cfg_reload, state),
                         )
                         process_sound_3.daemon = True
                         process_sound_3.start()

--- a/eqa/eqalert.py
+++ b/eqa/eqalert.py
@@ -995,6 +995,12 @@ def system_encounter(base_path, state, display_q, sound_q, new_message):
                 )
             )
             sound_q.put(eqa_struct.sound("speak", "Encounter Parse Disabled"))
+        elif new_message.rx == "clear":
+            encounter_q.put(
+                eqa_struct.message(
+                    eqa_settings.eqa_time(), "null", "clear", "null", "null"
+                )
+            )
         display_q.put(
             eqa_struct.display(eqa_settings.eqa_time(), "draw", "redraw", "null")
         )

--- a/eqa/eqalert.py
+++ b/eqa/eqalert.py
@@ -409,6 +409,11 @@ def main():
                     ### Update debug status
                     elif new_message.tx == "debug":
                         system_debug(base_path, state, display_q, sound_q, new_message)
+                    ### Update encounter parse status
+                    elif new_message.tx == "encounter":
+                        system_encounter(
+                            base_path, state, display_q, sound_q, new_message
+                        )
                     ### Update group status
                     elif new_message.tx == "group":
                         state.set_group(new_message.payload)
@@ -874,7 +879,7 @@ def system_debug(base_path, state, display_q, sound_q, new_message):
                 )
             )
             sound_q.put(
-                eqa_struct.sound("speak", "Displaying and logging all line matches")
+                eqa_struct.sound("speak", "Displaying and logging all parser output")
             )
         elif state.debug == "true" and new_message.rx == "toggle":
             state.set_debug("false")
@@ -895,6 +900,47 @@ def system_debug(base_path, state, display_q, sound_q, new_message):
     except Exception as e:
         eqa_settings.log(
             "system debug: Error on line "
+            + str(sys.exc_info()[-1].tb_lineno)
+            + ": "
+            + str(e)
+        )
+
+
+def system_encounter(base_path, state, display_q, sound_q, new_message):
+    """Perform system tasks for encounter parse behavior"""
+
+    try:
+        if state.encounter_parse == "false" and new_message.rx == "toggle":
+            state.set_encounter_parse("true")
+            eqa_config.set_last_state(state, base_path)
+            display_q.put(
+                eqa_struct.display(
+                    eqa_settings.eqa_time(),
+                    "event",
+                    "events",
+                    "Encounter Parse Enabled",
+                )
+            )
+            sound_q.put(eqa_struct.sound("speak", "Encounter Parse Enabled"))
+        elif state.encounter_parse == "true" and new_message.rx == "toggle":
+            state.set_encounter_parse("false")
+            eqa_config.set_last_state(state, base_path)
+            display_q.put(
+                eqa_struct.display(
+                    eqa_settings.eqa_time(),
+                    "event",
+                    "events",
+                    "Encounter Parse Disabled",
+                )
+            )
+            sound_q.put(eqa_struct.sound("speak", "Encounter Parse Disabled"))
+        display_q.put(
+            eqa_struct.display(eqa_settings.eqa_time(), "draw", "redraw", "null")
+        )
+
+    except Exception as e:
+        eqa_settings.log(
+            "system encounter: Error on line "
             + str(sys.exc_info()[-1].tb_lineno)
             + ": "
             + str(e)

--- a/eqa/eqalert.py
+++ b/eqa/eqalert.py
@@ -358,10 +358,9 @@ def main():
 
             # Sleep between empty checks
             queue_size = system_q.qsize()
-            if queue_size < 4:
+            if queue_size < 1:
                 time.sleep(0.01)
             else:
-                time.sleep(0.001)
                 if state.debug == "true":
                     eqa_settings.log("system_q depth: " + str(queue_size))
 

--- a/eqa/eqalert.py
+++ b/eqa/eqalert.py
@@ -987,6 +987,11 @@ def system_encounter(base_path, state, display_q, sound_q, encounter_q, new_mess
                     "Encounter Parse Enabled",
                 )
             )
+            encounter_q.put(
+                eqa_struct.message(
+                    eqa_settings.eqa_time(), "null", "clear", "null", "null"
+                )
+            )
             sound_q.put(eqa_struct.sound("speak", "Encounter Parse Enabled"))
         elif state.encounter_parse == "true" and new_message.rx == "toggle":
             state.set_encounter_parse("false")

--- a/eqa/eqalert.py
+++ b/eqa/eqalert.py
@@ -1006,6 +1006,12 @@ def system_encounter(base_path, state, display_q, sound_q, encounter_q, new_mess
                     eqa_settings.eqa_time(), "null", "clear", "null", "null"
                 )
             )
+        elif new_message.rx == "end":
+            encounter_q.put(
+                eqa_struct.message(
+                    eqa_settings.eqa_time(), "null", "end", "null", "null"
+                )
+            )
         display_q.put(
             eqa_struct.display(eqa_settings.eqa_time(), "draw", "redraw", "null")
         )

--- a/eqa/eqalert.py
+++ b/eqa/eqalert.py
@@ -450,7 +450,12 @@ def main():
                     ### Update encounter parse status
                     elif new_message.tx == "encounter":
                         system_encounter(
-                            base_path, state, display_q, sound_q, new_message
+                            base_path,
+                            state,
+                            display_q,
+                            sound_q,
+                            encounter_q,
+                            new_message,
                         )
                     ### Update group status
                     elif new_message.tx == "group":
@@ -967,7 +972,7 @@ def system_debug(base_path, state, display_q, sound_q, new_message):
         )
 
 
-def system_encounter(base_path, state, display_q, sound_q, new_message):
+def system_encounter(base_path, state, display_q, sound_q, encounter_q, new_message):
     """Perform system tasks for encounter parse behavior"""
 
     try:

--- a/eqa/eqalert.py
+++ b/eqa/eqalert.py
@@ -205,18 +205,11 @@ def main():
     ## Produce action_q
 
     ### Thread 1
-    process_parse_1 = threading.Thread(
+    process_parse = threading.Thread(
         target=eqa_parser.process, args=(exit_flag, log_q, action_q)
     )
-    process_parse_1.daemon = True
-    process_parse_1.start()
-
-    ### Thread 2
-    process_parse_2 = threading.Thread(
-        target=eqa_parser.process, args=(exit_flag, log_q, action_q)
-    )
-    process_parse_2.daemon = True
-    process_parse_2.start()
+    process_parse.daemon = True
+    process_parse.start()
 
     # Read Keyboard Events
     ## Consume keyboard events
@@ -248,11 +241,11 @@ def main():
     ## Consume action_q
     ## Produce display_q, sound_q, system_q
 
-    ### Shared Mute List
+    ### Mute List
     mute_list = []
 
     ### Thread 1
-    process_action_1 = threading.Thread(
+    process_action = threading.Thread(
         target=eqa_action.process,
         args=(
             config,
@@ -268,68 +261,8 @@ def main():
             mute_list,
         ),
     )
-    process_action_1.daemon = True
-    process_action_1.start()
-
-    ### Thread 2
-    process_action_2 = threading.Thread(
-        target=eqa_action.process,
-        args=(
-            config,
-            base_path,
-            state,
-            action_q,
-            encounter_q,
-            system_q,
-            display_q,
-            sound_q,
-            exit_flag,
-            cfg_reload,
-            mute_list,
-        ),
-    )
-    process_action_2.daemon = True
-    process_action_2.start()
-
-    ### Thread 3
-    process_action_3 = threading.Thread(
-        target=eqa_action.process,
-        args=(
-            config,
-            base_path,
-            state,
-            action_q,
-            encounter_q,
-            system_q,
-            display_q,
-            sound_q,
-            exit_flag,
-            cfg_reload,
-            mute_list,
-        ),
-    )
-    process_action_3.daemon = True
-    process_action_3.start()
-
-    ### Thread 4
-    process_action_4 = threading.Thread(
-        target=eqa_action.process,
-        args=(
-            config,
-            base_path,
-            state,
-            action_q,
-            encounter_q,
-            system_q,
-            display_q,
-            sound_q,
-            exit_flag,
-            cfg_reload,
-            mute_list,
-        ),
-    )
-    process_action_4.daemon = True
-    process_action_4.start()
+    process_action.daemon = True
+    process_action.start()
 
     # Produce display_q, system_q
     ## Consume encounter_q
@@ -627,10 +560,7 @@ def main():
                         state.set_guild(new_state.char_guild)
                         #### Stop state dependent processes
                         cfg_reload.set()
-                        process_action_1.join()
-                        process_action_2.join()
-                        process_action_3.join()
-                        process_action_4.join()
+                        process_action.join()
                         process_encounter.join()
                         process_sound_1.join()
                         process_sound_2.join()
@@ -656,7 +586,7 @@ def main():
                         #### Restart process_action
 
                         ##### Thread 1
-                        process_action_1 = threading.Thread(
+                        process_action = threading.Thread(
                             target=eqa_action.process,
                             args=(
                                 config,
@@ -672,68 +602,8 @@ def main():
                                 mute_list,
                             ),
                         )
-                        process_action_1.daemon = True
-                        process_action_1.start()
-
-                        ##### Thread 2
-                        process_action_2 = threading.Thread(
-                            target=eqa_action.process,
-                            args=(
-                                config,
-                                base_path,
-                                state,
-                                action_q,
-                                encounter_q,
-                                system_q,
-                                display_q,
-                                sound_q,
-                                exit_flag,
-                                cfg_reload,
-                                mute_list,
-                            ),
-                        )
-                        process_action_2.daemon = True
-                        process_action_2.start()
-
-                        ##### Thread 3
-                        process_action_3 = threading.Thread(
-                            target=eqa_action.process,
-                            args=(
-                                config,
-                                base_path,
-                                state,
-                                action_q,
-                                encounter_q,
-                                system_q,
-                                display_q,
-                                sound_q,
-                                exit_flag,
-                                cfg_reload,
-                                mute_list,
-                            ),
-                        )
-                        process_action_3.daemon = True
-                        process_action_3.start()
-
-                        ##### Thread 4
-                        process_action_4 = threading.Thread(
-                            target=eqa_action.process,
-                            args=(
-                                config,
-                                base_path,
-                                state,
-                                action_q,
-                                encounter_q,
-                                system_q,
-                                display_q,
-                                sound_q,
-                                exit_flag,
-                                cfg_reload,
-                                mute_list,
-                            ),
-                        )
-                        process_action_4.daemon = True
-                        process_action_4.start()
+                        process_action.daemon = True
+                        process_action.start()
 
                         #### Restart process_encounter
                         process_encounter = threading.Thread(
@@ -812,13 +682,9 @@ def main():
     )
     read_keys.join()
     process_log.join()
-    process_parse_1.join()
-    process_parse_2.join()
+    process_parse.join()
     process_keys.join()
-    process_action_1.join()
-    process_action_2.join()
-    process_action_3.join()
-    process_action_4.join()
+    process_action.join()
     process_encounter.join()
     process_sound_1.join()
     process_sound_2.join()

--- a/eqa/lib/action.py
+++ b/eqa/lib/action.py
@@ -115,17 +115,37 @@ def process(
                                 check_line,
                             )
                         )
-                    elif line_type == "engage":
+                    elif line_type == "spell_cast_other":
                         encounter_q.put(
                             eqa_struct.message(
                                 line_time,
                                 line_type,
-                                "combat",
+                                "spell",
+                                "null",
+                                check_line,
+                            )
+                        )
+                    elif line_type == "spell_cast_you":
+                        encounter_q.put(
+                            eqa_struct.message(
+                                line_time,
+                                line_type,
+                                "spell",
                                 "null",
                                 check_line,
                             )
                         )
                     elif line_type == "you_new_zone":
+                        encounter_q.put(
+                            eqa_struct.message(
+                                line_time,
+                                line_type,
+                                "stop",
+                                "null",
+                                check_line,
+                            )
+                        )
+                    elif line_type.startswith("experience_"):
                         encounter_q.put(
                             eqa_struct.message(
                                 line_time,

--- a/eqa/lib/action.py
+++ b/eqa/lib/action.py
@@ -1077,7 +1077,8 @@ def action_you_say_commands(
 
     try:
         if re.findall(r"(?<=You say, \'parser )[a-zA-Z\s]+", check_line) is not None:
-            args = re.findall(r"(?<=You say, \'parser )[a-zA-Z\s]+", check_line)[
+            check_line_clean = re.sub(r"[^\w\s\,]", "", check_line)
+            args = re.findall(r"(?<=You say, parser )[a-zA-Z\s]+", check_line_clean)[
                 0
             ].split(" ")
             if args[0] == "mute":
@@ -1124,7 +1125,7 @@ def action_you_say_commands(
                 elif args[1] in config["line"]:
                     if len(args) == 2:
                         if not (args[1], "all") in mute_list:
-                            mute_list.append(args[1], "all")
+                            mute_list.append((args[1], "all"))
                             display_q.put(
                                 eqa_struct.display(
                                     eqa_settings.eqa_time(),
@@ -1135,7 +1136,7 @@ def action_you_say_commands(
                             )
                     elif len(args) == 3:
                         if not (args[1], args[2]) in mute_list:
-                            mute_list.append(args[1], args[2])
+                            mute_list.append((args[1], args[2]))
                             display_q.put(
                                 eqa_struct.display(
                                     eqa_settings.eqa_time(),
@@ -1178,7 +1179,7 @@ def action_you_say_commands(
                 elif args[1] in config["line"]:
                     if len(args) == 2:
                         if (args[1], "all") in mute_list:
-                            mute_list.remove(args[1], "all")
+                            mute_list.remove((args[1], "all"))
                             display_q.put(
                                 eqa_struct.display(
                                     eqa_settings.eqa_time(),
@@ -1189,7 +1190,7 @@ def action_you_say_commands(
                             )
                     elif len(args) == 3:
                         if (args[1], args[2]) in mute_list:
-                            mute_list.remove(args[1], args[2])
+                            mute_list.remove((args[1], args[2]))
                             display_q.put(
                                 eqa_struct.display(
                                     eqa_settings.eqa_time(),
@@ -1246,6 +1247,16 @@ def action_you_say_commands(
                             "system",
                             "encounter",
                             "clear",
+                            "null",
+                        )
+                    )
+                elif args[1] == "end":
+                    system_q.put(
+                        eqa_struct.message(
+                            eqa_settings.eqa_time(),
+                            "system",
+                            "encounter",
+                            "end",
                             "null",
                         )
                     )

--- a/eqa/lib/action.py
+++ b/eqa/lib/action.py
@@ -1229,15 +1229,26 @@ def action_you_say_commands(
                     )
                 )
             elif args[0] == "encounter":
-                system_q.put(
-                    eqa_struct.message(
-                        eqa_settings.eqa_time(),
-                        "system",
-                        "encounter",
-                        "toggle",
-                        "null",
+                if len(args) == 1:
+                    system_q.put(
+                        eqa_struct.message(
+                            eqa_settings.eqa_time(),
+                            "system",
+                            "encounter",
+                            "toggle",
+                            "null",
+                        )
                     )
-                )
+                elif args[1] == "clear":
+                    system_q.put(
+                        eqa_struct.message(
+                            eqa_settings.eqa_time(),
+                            "system",
+                            "encounter",
+                            "clear",
+                            "null",
+                        )
+                    )
             elif args[0] == "what":
                 if len(args) == 1:
                     sound_q.put(eqa_struct.sound("speak", "What what?"))

--- a/eqa/lib/action.py
+++ b/eqa/lib/action.py
@@ -54,7 +54,7 @@ def process(
 
             # Sleep between empty checks
             queue_size = action_q.qsize()
-            if queue_size < 4:
+            if queue_size < 2:
                 time.sleep(0.01)
             else:
                 time.sleep(0.001)

--- a/eqa/lib/action.py
+++ b/eqa/lib/action.py
@@ -82,6 +82,18 @@ def process(
                         )
                     )
 
+                ## Encounter Parsing
+                if state.encounter_parse == "true":
+                    if line_type.startswith("combat_"):
+                        # encounter_parse_combat(line_type, check_line, other, things)
+                        pass
+                    elif line_type.startswith("spell_"):
+                        # encounter_parse_spell(line_type, check_line, other, things)
+                        pass
+                    elif line_type == "spell_heal_you":
+                        # encounter_parse_heal(line_type, check_line, other, things)
+                        pass
+
                 ## State Building Line Types
                 if line_type == "location":
                     action_location(system_q, check_line)
@@ -136,475 +148,62 @@ def process(
 
                 ## If line_type exists in the config
                 if line_type in config["line"].keys():
-                    ### If this line_type is alert
-                    if config["line"][line_type]["reaction"] == "alert":
-                        #### Check for any alerts
-                        for keyphrase, value in config["line"][line_type][
-                            "alert"
-                        ].items():
-                            # If the alert value is true
-                            if (
-                                str(keyphrase).lower() in check_line.lower()
-                                and value == "true"
-                            ):
-                                if config["line"][line_type]["sound"] != "false":
-                                    sound_q.put(eqa_struct.sound("alert", line_type))
-                                display_q.put(
-                                    eqa_struct.display(
-                                        eqa_settings.eqa_time(),
-                                        "event",
-                                        "events",
-                                        line_type + ": " + check_line,
-                                    )
-                                )
-                            # If the alert value is solo_only
-                            elif (
-                                str(keyphrase).lower() in check_line.lower()
-                                and value == "solo_only"
-                                and state.group == "false"
-                                and state.raid == "false"
-                            ):
-                                if config["line"][line_type]["sound"] != "false":
-                                    sound_q.put(eqa_struct.sound("speak", keyphrase))
-                                display_q.put(
-                                    eqa_struct.display(
-                                        eqa_settings.eqa_time(),
-                                        "event",
-                                        "events",
-                                        "Solo: " + line_type + ": " + check_line,
-                                    )
-                                )
-                            # If the alert value is solo
-                            elif (
-                                str(keyphrase).lower() in check_line.lower()
-                                and value == "solo"
-                                and state.group == "false"
-                                and state.raid == "false"
-                            ):
-                                if config["line"][line_type]["sound"] != "false":
-                                    sound_q.put(eqa_struct.sound("speak", keyphrase))
-                                display_q.put(
-                                    eqa_struct.display(
-                                        eqa_settings.eqa_time(),
-                                        "event",
-                                        "events",
-                                        "Solo: " + line_type + ": " + check_line,
-                                    )
-                                )
-                            # If the alert value is group
-                            elif (
-                                str(keyphrase).lower() in check_line.lower()
-                                and value == "group"
-                                and state.group == "true"
-                                and state.raid == "false"
-                            ):
-                                if keyphrase == "assist" or keyphrase == "rampage":
-                                    target = re.findall("^([\w\-]+)", check_line)
-                                    payload = keyphrase + " on " + target[0]
-                                else:
-                                    payload = keyphrase
-                                if config["line"][line_type]["sound"] != "false":
-                                    sound_q.put(eqa_struct.sound("speak", payload))
-                                display_q.put(
-                                    eqa_struct.display(
-                                        eqa_settings.eqa_time(),
-                                        "event",
-                                        "events",
-                                        "Group: " + line_type + ": " + check_line,
-                                    )
-                                )
-                            # If the alert value is group_only
-                            elif (
-                                str(keyphrase).lower() in check_line.lower()
-                                and value == "group_only"
-                                and state.group == "true"
-                                and state.raid == "false"
-                            ):
-                                if keyphrase == "assist" or keyphrase == "rampage":
-                                    target = re.findall("^([\w\-]+)", check_line)
-                                    payload = keyphrase + " on " + target[0]
-                                else:
-                                    payload = keyphrase
-                                if config["line"][line_type]["sound"] != "false":
-                                    sound_q.put(eqa_struct.sound("speak", payload))
-                                display_q.put(
-                                    eqa_struct.display(
-                                        eqa_settings.eqa_time(),
-                                        "event",
-                                        "events",
-                                        "Group: " + line_type + ": " + check_line,
-                                    )
-                                )
-                            # If the alert value is solo, but you are grouped
-                            elif (
-                                str(keyphrase).lower() in check_line.lower()
-                                and value == "solo"
-                                and state.group == "true"
-                                and state.raid == "false"
-                            ):
-                                if config["line"][line_type]["sound"] != "false":
-                                    sound_q.put(eqa_struct.sound("speak", keyphrase))
-                                display_q.put(
-                                    eqa_struct.display(
-                                        eqa_settings.eqa_time(),
-                                        "event",
-                                        "events",
-                                        "Group: " + line_type + ": " + check_line,
-                                    )
-                                )
-                            # If the alert value is solo_group_only
-                            elif (
-                                str(keyphrase).lower() in check_line.lower()
-                                and value == "solo_group_only"
-                                and state.raid == "false"
-                            ):
-                                if config["line"][line_type]["sound"] != "false":
-                                    sound_q.put(eqa_struct.sound("speak", keyphrase))
-                                display_q.put(
-                                    eqa_struct.display(
-                                        eqa_settings.eqa_time(),
-                                        "event",
-                                        "events",
-                                        "Solo/Group: " + line_type + ": " + check_line,
-                                    )
-                                )
-                            # If the alert value is raid
-                            elif (
-                                str(keyphrase).lower() in check_line.lower()
-                                and value == "raid"
-                                and state.raid == "true"
-                            ):
-                                if keyphrase == "assist" or keyphrase == "rampage":
-                                    target = re.findall("^([\w\-]+)", check_line)
-                                    payload = keyphrase + " on " + target[0]
-                                else:
-                                    payload = keyphrase
-                                if config["line"][line_type]["sound"] != "false":
-                                    sound_q.put(eqa_struct.sound("speak", payload))
-                                display_q.put(
-                                    eqa_struct.display(
-                                        eqa_settings.eqa_time(),
-                                        "event",
-                                        "events",
-                                        line_type + ": " + check_line,
-                                    )
-                                )
-                            # If the alert value is group, but you are in a raid
-                            elif (
-                                str(keyphrase).lower() in check_line.lower()
-                                and value == "group"
-                                and state.raid == "true"
-                            ):
-                                if keyphrase == "assist" or keyphrase == "rampage":
-                                    target = re.findall("^([\w\-]+)", check_line)
-                                    payload = keyphrase + " on " + target[0]
-                                else:
-                                    payload = keyphrase
-                                if config["line"][line_type]["sound"] != "false":
-                                    sound_q.put(eqa_struct.sound("speak", payload))
-                                display_q.put(
-                                    eqa_struct.display(
-                                        eqa_settings.eqa_time(),
-                                        "event",
-                                        "events",
-                                        line_type + ": " + check_line,
-                                    )
-                                )
-                            # If the alert value is solo, but you are in a raid
-                            elif (
-                                str(keyphrase).lower() in check_line.lower()
-                                and value == "solo"
-                                and state.raid == "true"
-                            ):
-                                if keyphrase == "assist" or keyphrase == "rampage":
-                                    target = re.findall("^([\w\-]+)", check_line)
-                                    payload = keyphrase + " on " + target[0]
-                                else:
-                                    payload = keyphrase
-                                if config["line"][line_type]["sound"] != "false":
-                                    sound_q.put(eqa_struct.sound("speak", payload))
-                                display_q.put(
-                                    eqa_struct.display(
-                                        eqa_settings.eqa_time(),
-                                        "event",
-                                        "events",
-                                        line_type + ": " + check_line,
-                                    )
-                                )
 
-                    # Or if line_type reaction is all
-                    elif config["line"][line_type]["reaction"] == "all":
+                    reaction = config["line"][line_type]["reaction"]
 
-                        sender = re.findall(r"^\w+", check_line)
-                        if (
-                            config["line"][line_type]["sound"] == "true"
-                            and not (line_type, sender[0].lower()) in mute_list
-                            and not (line_type, "all") in mute_list
-                        ):
-                            sound_q.put(eqa_struct.sound("speak", check_line))
-                        elif config["line"][line_type]["sound"] != "false":
-                            sound_q.put(eqa_struct.sound("alert", line_type))
-                        display_q.put(
-                            eqa_struct.display(
-                                eqa_settings.eqa_time(),
-                                "event",
-                                "events",
-                                line_type + ": " + check_line,
-                            )
+                    ### Handle Alert Reactions
+                    if reaction == "alert":
+                        reaction_alert(
+                            line_type,
+                            check_line,
+                            config,
+                            sound_q,
+                            display_q,
+                            state,
+                            mute_list,
                         )
 
-                    # Or if line_type reaction is solo_only and you are solo and not in a raid
-                    elif (
-                        config["line"][line_type]["reaction"] == "solo_only"
-                        and state.group == "false"
-                        and state.raid == "false"
-                    ):
-                        sender = re.findall(r"^\w+", check_line)
-                        if (
-                            config["line"][line_type]["sound"] == "true"
-                            and not (line_type, sender[0].lower()) in mute_list
-                            and not (line_type, "all") in mute_list
-                        ):
-                            sound_q.put(eqa_struct.sound("speak", check_line))
-                        elif config["line"][line_type]["sound"] != "false":
-                            sound_q.put(eqa_struct.sound("alert", line_type))
-                        display_q.put(
-                            eqa_struct.display(
-                                eqa_settings.eqa_time(),
-                                "event",
-                                "events",
-                                check_line,
-                            )
+                    ### Handle Context Reactions
+                    elif reaction != "false":
+                        reaction_context(
+                            line_type,
+                            check_line,
+                            config,
+                            sound_q,
+                            display_q,
+                            state,
+                            mute_list,
+                            reaction,
                         )
 
-                    # Or if line_type reaction is solo and you are solo and not in a raid
-                    elif (
-                        config["line"][line_type]["reaction"] == "solo"
-                        and state.group == "false"
-                        and state.raid == "false"
-                    ):
-                        sender = re.findall(r"^\w+", check_line)
-                        if (
-                            config["line"][line_type]["sound"] == "true"
-                            and not (line_type, sender[0].lower()) in mute_list
-                            and not (line_type, "all") in mute_list
-                        ):
-                            sound_q.put(eqa_struct.sound("speak", check_line))
-                        elif config["line"][line_type]["sound"] != "false":
-                            sound_q.put(eqa_struct.sound("alert", line_type))
-                        display_q.put(
-                            eqa_struct.display(
-                                eqa_settings.eqa_time(),
-                                "event",
-                                "events",
-                                check_line,
-                            )
+                    ### Handle alert reactions for all lines
+                    if config["line"]["all"]["reaction"] == "alert":
+                        reaction_alert(
+                            "all",
+                            check_line,
+                            config,
+                            sound_q,
+                            display_q,
+                            state,
+                            mute_list,
                         )
 
-                    # Or if line_type reaction is solo and you are grouped but not in a raid
-                    elif (
-                        config["line"][line_type]["reaction"] == "solo"
-                        and state.group == "true"
-                        and state.raid == "false"
-                    ):
-                        sender = re.findall(r"^\w+", check_line)
-                        if (
-                            config["line"][line_type]["sound"] == "true"
-                            and not (line_type, sender[0].lower()) in mute_list
-                            and not (line_type, "all") in mute_list
-                        ):
-                            sound_q.put(eqa_struct.sound("speak", check_line))
-                        elif config["line"][line_type]["sound"] != "false":
-                            sound_q.put(eqa_struct.sound("alert", line_type))
-                        display_q.put(
-                            eqa_struct.display(
-                                eqa_settings.eqa_time(),
-                                "event",
-                                "events",
-                                check_line,
-                            )
+                    ### Handle context reaction for all lines
+                    elif config["line"]["all"]["reaction"] != "false":
+                        reaction_context(
+                            "all",
+                            check_line,
+                            config,
+                            sound_q,
+                            display_q,
+                            state,
+                            mute_list,
+                            config["line"]["all"]["reaction"],
                         )
 
-                    # Or if line_type reaction is solo_group_only and you are not in a raid
-                    elif (
-                        config["line"][line_type]["reaction"] == "solo_group_only"
-                        and state.raid == "false"
-                    ):
-                        sender = re.findall(r"^\w+", check_line)
-                        if (
-                            config["line"][line_type]["sound"] == "true"
-                            and not (line_type, sender[0].lower()) in mute_list
-                            and not (line_type, "all") in mute_list
-                        ):
-                            sound_q.put(eqa_struct.sound("speak", check_line))
-                        elif config["line"][line_type]["sound"] != "false":
-                            sound_q.put(eqa_struct.sound("alert", line_type))
-                        display_q.put(
-                            eqa_struct.display(
-                                eqa_settings.eqa_time(),
-                                "event",
-                                "events",
-                                check_line,
-                            )
-                        )
-
-                    # Or if line_type reaction group_only and you are grouped but not in a raid
-                    elif (
-                        config["line"][line_type]["reaction"] == "group_only"
-                        and state.group == "true"
-                        and state.raid == "false"
-                    ):
-                        sender = re.findall(r"^\w+", check_line)
-                        if (
-                            config["line"][line_type]["sound"] == "true"
-                            and not (line_type, sender[0].lower()) in mute_list
-                            and not (line_type, "all") in mute_list
-                        ):
-                            sound_q.put(eqa_struct.sound("speak", check_line))
-                        elif config["line"][line_type]["sound"] != "false":
-                            sound_q.put(eqa_struct.sound("alert", line_type))
-                        display_q.put(
-                            eqa_struct.display(
-                                eqa_settings.eqa_time(),
-                                "event",
-                                "events",
-                                check_line,
-                            )
-                        )
-
-                    # Or if line_type reaction is group and you are grouped but not in a raid
-                    elif (
-                        config["line"][line_type]["reaction"] == "group"
-                        and state.group == "true"
-                        and state.raid == "false"
-                    ):
-                        sender = re.findall(r"^\w+", check_line)
-                        if (
-                            config["line"][line_type]["sound"] == "true"
-                            and not (line_type, sender[0].lower()) in mute_list
-                            and not (line_type, "all") in mute_list
-                        ):
-                            sound_q.put(eqa_struct.sound("speak", check_line))
-                        elif config["line"][line_type]["sound"] != "false":
-                            sound_q.put(eqa_struct.sound("alert", line_type))
-                        display_q.put(
-                            eqa_struct.display(
-                                eqa_settings.eqa_time(),
-                                "event",
-                                "events",
-                                check_line,
-                            )
-                        )
-
-                    # Or if line_type reaction is solo regardless of group state and in a raid
-                    elif (
-                        config["line"][line_type]["reaction"] == "solo"
-                        and state.raid == "true"
-                    ):
-                        sender = re.findall(r"^\w+", check_line)
-                        if (
-                            config["line"][line_type]["sound"] == "true"
-                            and not (line_type, sender[0].lower()) in mute_list
-                            and not (line_type, "all") in mute_list
-                        ):
-                            sound_q.put(eqa_struct.sound("speak", check_line))
-                        elif config["line"][line_type]["sound"] != "false":
-                            sound_q.put(eqa_struct.sound("alert", line_type))
-                        display_q.put(
-                            eqa_struct.display(
-                                eqa_settings.eqa_time(),
-                                "event",
-                                "events",
-                                check_line,
-                            )
-                        )
-
-                    # Or if line_type reaction is group regardless of group state and in a raid
-                    elif (
-                        config["line"][line_type]["reaction"] == "group"
-                        and state.raid == "true"
-                    ):
-                        sender = re.findall(r"^\w+", check_line)
-                        if (
-                            config["line"][line_type]["sound"] == "true"
-                            and not (line_type, sender[0].lower()) in mute_list
-                            and not (line_type, "all") in mute_list
-                        ):
-                            sound_q.put(eqa_struct.sound("speak", check_line))
-                        elif config["line"][line_type]["sound"] != "false":
-                            sound_q.put(eqa_struct.sound("alert", line_type))
-                        display_q.put(
-                            eqa_struct.display(
-                                eqa_settings.eqa_time(),
-                                "event",
-                                "events",
-                                check_line,
-                            )
-                        )
-
-                    # Or if line_type reaction is raid regardless of group state and in a raid
-                    elif (
-                        config["line"][line_type]["reaction"] == "raid"
-                        and state.raid == "true"
-                    ):
-                        sender = re.findall(r"^\w+", check_line)
-                        if (
-                            config["line"][line_type]["sound"] == "true"
-                            and not (line_type, sender[0].lower()) in mute_list
-                            and not (line_type, "all") in mute_list
-                        ):
-                            sound_q.put(eqa_struct.sound("speak", check_line))
-                        elif config["line"][line_type]["sound"] != "false":
-                            sound_q.put(eqa_struct.sound("alert", line_type))
-                        display_q.put(
-                            eqa_struct.display(
-                                eqa_settings.eqa_time(),
-                                "event",
-                                "events",
-                                check_line,
-                            )
-                        )
-
-                    # Or if line_type reaction is afk and you are afk
-                    elif (
-                        config["line"][line_type]["reaction"] == "afk"
-                        and state.afk == "true"
-                    ):
-                        sender = re.findall(r"^\w+", check_line)
-                        if (
-                            config["line"][line_type]["sound"] == "true"
-                            and not (line_type, sender[0].lower()) in mute_list
-                            and not (line_type, "all") in mute_list
-                        ):
-                            sound_q.put(eqa_struct.sound("speak", check_line))
-                        elif config["line"][line_type]["sound"] != "false":
-                            sound_q.put(eqa_struct.sound("alert", line_type))
-                        display_q.put(
-                            eqa_struct.display(
-                                eqa_settings.eqa_time(),
-                                "event",
-                                "events",
-                                check_line,
-                            )
-                        )
-
-                    # For alerts for all matched lines
-                    if config["line"]["all"]["reaction"] == "true":
-                        for keyphrase, value in config["alert"]["all"].items():
-                            if keyphrase in check_line.lower():
-                                if config["line"]["all"]["sound"] != "false":
-                                    sound_q.put(eqa_struct.sound("alert", line_type))
-                                display_q.put(
-                                    eqa_struct.display(
-                                        eqa_settings.eqa_time(),
-                                        "event",
-                                        "events",
-                                        line_type + ": " + check_line,
-                                    )
-                                )
-
-                # If line_type is not in the config
+                ## If line_type is not in the config
                 else:
+                    ### Add new line type
                     eqa_config.add_type(line_type, base_path)
                     display_q.put(
                         eqa_struct.display(
@@ -635,6 +234,391 @@ def process(
         )
 
     sys.exit(0)
+
+
+def send_alerts(
+    line_type, check_line, config, sound_q, display_q, keyphrase, mute_list
+):
+    """Send messages to sound and display queues"""
+
+    try:
+        # Check Sender
+        sender = re.findall(r"^([\w\-]+)", check_line)
+
+        if config["line"][line_type]["sound"] == "true":
+            if keyphrase != "false":
+                if (
+                    keyphrase == "assist"
+                    or keyphrase == "rampage"
+                    or keyphrase == "spot"
+                ):
+                    payload = keyphrase + " on " + sender[0]
+                else:
+                    payload = keyphrase
+                if (
+                    not (line_type, sender[0].lower()) in mute_list
+                    and not (line_type, "all") in mute_list
+                ):
+                    sound_q.put(eqa_struct.sound("speak", payload))
+                display_q.put(
+                    eqa_struct.display(
+                        eqa_settings.eqa_time(),
+                        "event",
+                        "events",
+                        line_type + ": [" + payload + "] " + check_line,
+                    )
+                )
+            else:
+                if (
+                    not (line_type, sender[0].lower()) in mute_list
+                    and not (line_type, "all") in mute_list
+                ):
+                    sound_q.put(eqa_struct.sound("speak", check_line))
+                display_q.put(
+                    eqa_struct.display(
+                        eqa_settings.eqa_time(),
+                        "event",
+                        "events",
+                        line_type + ": " + check_line,
+                    )
+                )
+
+        elif config["line"][line_type]["sound"] != "false":
+            if keyphrase != "false":
+                if (
+                    keyphrase == "assist"
+                    or keyphrase == "rampage"
+                    or keyphrase == "spot"
+                ):
+                    payload = keyphrase + " on " + sender[0]
+                else:
+                    payload = keyphrase
+                if (
+                    not (line_type, sender[0].lower()) in mute_list
+                    and not (line_type, "all") in mute_list
+                ):
+                    sound_q.put(eqa_struct.sound("speak", payload))
+                display_q.put(
+                    eqa_struct.display(
+                        eqa_settings.eqa_time(),
+                        "event",
+                        "events",
+                        line_type + ": [" + payload + "] " + check_line,
+                    )
+                )
+            else:
+                if (
+                    not (line_type, sender[0].lower()) in mute_list
+                    and not (line_type, "all") in mute_list
+                ):
+                    sound_q.put(eqa_struct.sound("alert", line_type))
+                display_q.put(
+                    eqa_struct.display(
+                        eqa_settings.eqa_time(),
+                        "event",
+                        "events",
+                        line_type + ": " + check_line,
+                    )
+                )
+
+    except Exception as e:
+        eqa_settings.log(
+            "send alerts: Error on line "
+            + str(sys.exc_info()[-1].tb_lineno)
+            + ": "
+            + str(e)
+        )
+
+
+def reaction_context(
+    line_type, check_line, config, sound_q, display_q, state, mute_list, reaction
+):
+    """Reactions for when reaction is a context"""
+
+    try:
+        # Or if line_type reaction is all
+        if reaction == "all":
+            send_alerts(
+                line_type,
+                check_line,
+                config,
+                sound_q,
+                display_q,
+                "false",
+                mute_list,
+            )
+
+        # Or if line_type reaction is solo_only and you are solo and not in a raid
+        elif (
+            reaction == "solo_only" and state.group == "false" and state.raid == "false"
+        ):
+            send_alerts(
+                line_type,
+                check_line,
+                config,
+                sound_q,
+                display_q,
+                "false",
+                mute_list,
+            )
+
+        # Or if line_type reaction is solo and you are solo and not in a raid
+        elif reaction == "solo" and state.group == "false" and state.raid == "false":
+            send_alerts(
+                line_type,
+                check_line,
+                config,
+                sound_q,
+                display_q,
+                "false",
+                mute_list,
+            )
+
+        # Or if line_type reaction is solo and you are grouped but not in a raid
+        elif reaction == "solo" and state.group == "true" and state.raid == "false":
+            send_alerts(
+                line_type,
+                check_line,
+                config,
+                sound_q,
+                display_q,
+                "false",
+                mute_list,
+            )
+
+        # Or if line_type reaction is solo_group_only and you are not in a raid
+        elif reaction == "solo_group_only" and state.raid == "false":
+            send_alerts(
+                line_type,
+                check_line,
+                config,
+                sound_q,
+                display_q,
+                "false",
+                mute_list,
+            )
+
+        # Or if line_type reaction group_only and you are grouped but not in a raid
+        elif (
+            reaction == "group_only" and state.group == "true" and state.raid == "false"
+        ):
+            send_alerts(
+                line_type,
+                check_line,
+                config,
+                sound_q,
+                display_q,
+                "false",
+                mute_list,
+            )
+
+        # Or if line_type reaction is group and you are grouped but not in a raid
+        elif reaction == "group" and state.group == "true" and state.raid == "false":
+            send_alerts(
+                line_type,
+                check_line,
+                config,
+                sound_q,
+                display_q,
+                "false",
+                mute_list,
+            )
+
+        # Or if line_type reaction is solo regardless of group state and in a raid
+        elif reaction == "solo" and state.raid == "true":
+            send_alerts(
+                line_type,
+                check_line,
+                config,
+                sound_q,
+                display_q,
+                "false",
+                mute_list,
+            )
+
+        # Or if line_type reaction is group regardless of group state and in a raid
+        elif reaction == "group" and state.raid == "true":
+            send_alerts(
+                line_type,
+                check_line,
+                config,
+                sound_q,
+                display_q,
+                "false",
+                mute_list,
+            )
+
+        # Or if line_type reaction is raid regardless of group state and in a raid
+        elif reaction == "raid" and state.raid == "true":
+            send_alerts(
+                line_type,
+                check_line,
+                config,
+                sound_q,
+                display_q,
+                "false",
+                mute_list,
+            )
+
+        # Or if line_type reaction is afk and you are afk
+        elif reaction == "afk" and state.afk == "true":
+            send_alerts(
+                line_type,
+                check_line,
+                config,
+                sound_q,
+                display_q,
+                "false",
+                mute_list,
+            )
+
+    except Exception as e:
+        eqa_settings.log(
+            "reaction context: Error on line "
+            + str(sys.exc_info()[-1].tb_lineno)
+            + ": "
+            + str(e)
+        )
+
+
+def reaction_alert(line_type, check_line, config, sound_q, display_q, state, mute_list):
+    """Reactions for when reaction is alert"""
+
+    try:
+        for keyphrase, value in config["line"][line_type]["alert"].items():
+            # If the alert value is true
+            if str(keyphrase).lower() in check_line.lower():
+                if value == "true":
+                    send_alerts(
+                        line_type,
+                        check_line,
+                        config,
+                        sound_q,
+                        display_q,
+                        keyphrase,
+                        mute_list,
+                    )
+                # If the alert value is solo_only
+                elif (
+                    value == "solo_only"
+                    and state.group == "false"
+                    and state.raid == "false"
+                ):
+                    send_alerts(
+                        line_type,
+                        check_line,
+                        config,
+                        sound_q,
+                        display_q,
+                        keyphrase,
+                        mute_list,
+                    )
+                # If the alert value is solo
+                elif (
+                    value == "solo" and state.group == "false" and state.raid == "false"
+                ):
+                    send_alerts(
+                        line_type,
+                        check_line,
+                        config,
+                        sound_q,
+                        display_q,
+                        keyphrase,
+                        mute_list,
+                    )
+                # If the alert value is group
+                elif (
+                    value == "group" and state.group == "true" and state.raid == "false"
+                ):
+                    send_alerts(
+                        line_type,
+                        check_line,
+                        config,
+                        sound_q,
+                        display_q,
+                        keyphrase,
+                        mute_list,
+                    )
+                # If the alert value is group_only
+                elif (
+                    value == "group_only"
+                    and state.group == "true"
+                    and state.raid == "false"
+                ):
+                    send_alerts(
+                        line_type,
+                        check_line,
+                        config,
+                        sound_q,
+                        display_q,
+                        keyphrase,
+                        mute_list,
+                    )
+                # If the alert value is solo, but you are grouped
+                elif (
+                    value == "solo" and state.group == "true" and state.raid == "false"
+                ):
+                    send_alerts(
+                        line_type,
+                        check_line,
+                        config,
+                        sound_q,
+                        display_q,
+                        keyphrase,
+                        mute_list,
+                    )
+                # If the alert value is solo_group_only
+                elif value == "solo_group_only" and state.raid == "false":
+                    send_alerts(
+                        line_type,
+                        check_line,
+                        config,
+                        sound_q,
+                        display_q,
+                        keyphrase,
+                        mute_list,
+                    )
+                # If the alert value is raid
+                elif value == "raid" and state.raid == "true":
+                    send_alerts(
+                        line_type,
+                        check_line,
+                        config,
+                        sound_q,
+                        display_q,
+                        keyphrase,
+                        mute_list,
+                    )
+                # If the alert value is group, but you are in a raid
+                elif value == "group" and state.raid == "true":
+                    send_alerts(
+                        line_type,
+                        check_line,
+                        config,
+                        sound_q,
+                        display_q,
+                        keyphrase,
+                        mute_list,
+                    )
+                # If the alert value is solo, but you are in a raid
+                elif value == "solo" and state.raid == "true":
+                    send_alerts(
+                        line_type,
+                        check_line,
+                        config,
+                        sound_q,
+                        display_q,
+                        keyphrase,
+                        mute_list,
+                    )
+
+    except Exception as e:
+        eqa_settings.log(
+            "reaction alert: Error on line "
+            + str(sys.exc_info()[-1].tb_lineno)
+            + ": "
+            + str(e)
+        )
 
 
 def action_motd_welcome(system_q):
@@ -1101,6 +1085,16 @@ def action_you_say_commands(
                         "system",
                         "reload_config",
                         "null",
+                        "null",
+                    )
+                )
+            elif args[0] == "encounter":
+                system_q.put(
+                    eqa_struct.message(
+                        eqa_settings.eqa_time(),
+                        "system",
+                        "encounter",
+                        "toggle",
                         "null",
                     )
                 )

--- a/eqa/lib/action.py
+++ b/eqa/lib/action.py
@@ -54,10 +54,9 @@ def process(
 
             # Sleep between empty checks
             queue_size = action_q.qsize()
-            if queue_size < 2:
+            if queue_size < 1:
                 time.sleep(0.01)
             else:
-                time.sleep(0.001)
                 if state.debug == "true":
                     eqa_settings.log("action_q depth: " + str(queue_size))
 

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -1082,7 +1082,7 @@ def build_config(base_path):
     },
     "spell_slow_on": {
       "alert": {},
-      "reaction": "solo",
+      "reaction": "solo_group_only",
       "sound": "slowed"
     },
     "spell_sow_off_you": {

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -1350,6 +1350,7 @@ def build_config(base_path):
     "paths": {
       "alert_log": "%slog/",
       "data": "%sdata/",
+      "encounter": "%sencounters/",
       "char_log": "%s/.wine/drive_c/Program Files/Sony/EverQuest/Logs/",
       "sound": "%ssound/",
       "tmp_sound": "/tmp/eqa/sound/"
@@ -1463,7 +1464,7 @@ def build_config(base_path):
 
     try:
         f = open(base_path + "config.json", "w", encoding="utf-8")
-        f.write(new_config % (base_path, base_path, home, base_path))
+        f.write(new_config % (base_path, base_path, base_path, home, base_path))
         f.close()
 
     except Exception as e:

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -152,7 +152,7 @@ def bootstrap_state(base_path, char, server):
                 "mute": "false",
                 "group": "false",
                 "leader": "false",
-                "encounter_parse": "false",
+                "encounter_parse": "true",
             }
         )
         json_data = open(base_path + "config.json", "w", encoding="utf-8")
@@ -1360,7 +1360,10 @@ def build_config(base_path):
       "sound": "%ssound/",
       "tmp_sound": "/tmp/eqa/sound/"
     },
-    "version": "2.11.0"
+    "encounter_parsing": {
+      "auto_save": "false"
+    },
+    "version": "2.11.1"
   },
   "zones": {
     "An Arena (PVP) Area": "false",

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -152,6 +152,7 @@ def bootstrap_state(base_path, char, server):
                 "mute": "false",
                 "group": "false",
                 "leader": "false",
+                "encounter_parse": "false",
             }
         )
         json_data = open(base_path + "config.json", "w", encoding="utf-8")
@@ -203,6 +204,7 @@ def set_last_state(state, base_path):
                 "mute": str(state.mute),
                 "group": str(state.group),
                 "leader": str(state.leader),
+                "encounter_parse": str(state.encounter_parse),
             }
         )
         data["char_logs"][state.char + "_" + state.server].update(
@@ -296,6 +298,7 @@ def get_last_state(base_path, char_name, char_server):
         mute = data["last_state"]["mute"]
         group = data["last_state"]["group"]
         leader = data["last_state"]["leader"]
+        encounter_parse = data["last_state"]["encounter_parse"]
 
         # Get chars
         chars = get_config_chars(data)
@@ -319,6 +322,7 @@ def get_last_state(base_path, char_name, char_server):
             char_level,
             char_class,
             char_guild,
+            encounter_parse,
         )
 
         return state
@@ -855,7 +859,8 @@ def build_config(base_path):
     },
     "say": {
       "alert": {
-        "help": "true"
+        "help": "true",
+        "spot": "raid"
       },
       "reaction": "alert",
       "sound": "look at say"

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -452,6 +452,11 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "combat_other_melee_invulnerable": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "combat_other_melee_miss": {
       "alert": {},
       "reaction": "false",
@@ -487,22 +492,27 @@ def build_config(base_path):
       "reaction": "afk",
       "sound": "danger will robinson"
     },
-    "combat_you_stun_off": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
-    },
-    "combat_you_stun_on": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
-    },
     "command_block": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
     },
+    "command_block_casting": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "command_invalid": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "command_error": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "consider_no_target": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -1035,6 +1045,11 @@ def build_config(base_path):
       "reaction": "raid",
       "sound": "did not hold"
     },
+    "spell_protected": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "spell_recover_other": {
       "alert": {},
       "reaction": "false",
@@ -1230,6 +1245,16 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "you_auto_attack_off": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "you_auto_attack_on": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "you_camping": {
       "alert": {},
       "reaction": "false",
@@ -1300,6 +1325,16 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "you_stun_off": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "you_stun_on": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "zone_message": {
       "alert": {},
       "reaction": "all",
@@ -1314,6 +1349,7 @@ def build_config(base_path):
   "settings": {
     "paths": {
       "alert_log": "%slog/",
+      "data": "%sdata/",
       "char_log": "%s/.wine/drive_c/Program Files/Sony/EverQuest/Logs/",
       "sound": "%ssound/",
       "tmp_sound": "/tmp/eqa/sound/"
@@ -1427,7 +1463,7 @@ def build_config(base_path):
 
     try:
         f = open(base_path + "config.json", "w", encoding="utf-8")
-        f.write(new_config % (base_path, home, base_path))
+        f.write(new_config % (base_path, base_path, home, base_path))
         f.close()
 
     except Exception as e:

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -711,6 +711,7 @@ def build_config(base_path):
         "sieve": "raid",
         "slow": "raid",
         "snare": "raid",
+        "stand": "raid",
         "sunder": "raid",
         "tash": "raid"
       },
@@ -1026,8 +1027,8 @@ def build_config(base_path):
     },
     "spell_not_hold": {
       "alert": {},
-      "reaction": "false",
-      "sound": "false"
+      "reaction": "raid",
+      "sound": "did not hold"
     },
     "spell_recover_other": {
       "alert": {},
@@ -1312,7 +1313,7 @@ def build_config(base_path):
       "sound": "%ssound/",
       "tmp_sound": "/tmp/eqa/sound/"
     },
-    "version": "2.10.3"
+    "version": "2.11.0"
   },
   "zones": {
     "An Arena (PVP) Area": "false",

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -1235,6 +1235,11 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "wrong_key": {
+      "alert": {},
+      "reaction": "all",
+      "sound": "wrong key or place"
+    },
     "you_afk_off": {
       "alert": {},
       "reaction": "false",

--- a/eqa/lib/curses.py
+++ b/eqa/lib/curses.py
@@ -536,12 +536,12 @@ def draw_events_encounter(stdscr, encounter_report):
 
         # Target Stats
         count = 2
-        max_encounter_string_x = encounter_win_x - 34
+        seven_g = int(first_quarter / 2)
         for entry in encounter_report["target"]:
             if entry != "name":
-                encounterscr.addstr(count, 1, entry, curses.color_pair(3))
+                encounterscr.addstr(count, 1, entry.title(), curses.color_pair(3))
                 encounterscr.addstr(
-                    count, first_quarter + 2, encounter_report["target"][entry], curses.color_pair(1)
+                    count, first_quarter + 2, str(encounter_report["target"][entry])[:seven_g].title(), curses.color_pair(1)
                 )
                 count += 1
 

--- a/eqa/lib/curses.py
+++ b/eqa/lib/curses.py
@@ -603,11 +603,16 @@ def draw_state(stdscr, state):
         stdscr.addstr(24, 16, ": ", curses.color_pair(1))
         stdscr.addstr(24, 18, state.mute.title(), curses.color_pair(3))
 
+        # enounter parse state
+        stdscr.addstr(25, 5, "Encounter", curses.color_pair(2))
+        stdscr.addstr(25, 16, ": ", curses.color_pair(1))
+        stdscr.addstr(25, 18, state.encounter_parse.title(), curses.color_pair(3))
+
         # eqalert version
         version = str(pkg_resources.get_distribution("eqalert").version)
-        stdscr.addstr(26, 5, "Version", curses.color_pair(2))
-        stdscr.addstr(26, 16, ": ", curses.color_pair(1))
-        stdscr.addstr(26, 18, version, curses.color_pair(3))
+        stdscr.addstr(28, 5, "Version", curses.color_pair(2))
+        stdscr.addstr(28, 16, ": ", curses.color_pair(1))
+        stdscr.addstr(28, 18, version, curses.color_pair(3))
 
     except Exception as e:
         eqa_settings.log(
@@ -750,34 +755,38 @@ def draw_help(stdscr):
 
         stdscr.addstr(18, 9, "d", curses.color_pair(2))
         stdscr.addstr(18, 15, ":", curses.color_pair(1))
-        stdscr.addstr(18, 17, "Toggle debug modes", curses.color_pair(3))
+        stdscr.addstr(18, 17, "Toggle debug mode", curses.color_pair(3))
 
-        stdscr.addstr(19, 9, "m", curses.color_pair(2))
+        stdscr.addstr(19, 9, "e", curses.color_pair(2))
         stdscr.addstr(19, 15, ":", curses.color_pair(1))
-        stdscr.addstr(19, 17, "Toggle mute", curses.color_pair(3))
+        stdscr.addstr(19, 17, "Toggle encounter parsing", curses.color_pair(3))
+
+        stdscr.addstr(20, 9, "m", curses.color_pair(2))
+        stdscr.addstr(20, 15, ":", curses.color_pair(1))
+        stdscr.addstr(20, 17, "Toggle mute", curses.color_pair(3))
 
         # Settings commands
-        stdscr.addstr(21, 7, "Settings", curses.color_pair(1))
+        stdscr.addstr(22, 7, "Settings", curses.color_pair(1))
 
-        stdscr.addstr(22, 9, "up", curses.color_pair(2))
-        stdscr.addstr(22, 15, ":", curses.color_pair(1))
-        stdscr.addstr(22, 17, "Cycle up in selection", curses.color_pair(3))
-
-        stdscr.addstr(23, 9, "down", curses.color_pair(2))
+        stdscr.addstr(23, 9, "up", curses.color_pair(2))
         stdscr.addstr(23, 15, ":", curses.color_pair(1))
-        stdscr.addstr(23, 17, "Cycle down in selection", curses.color_pair(3))
+        stdscr.addstr(23, 17, "Cycle up in selection", curses.color_pair(3))
 
-        stdscr.addstr(24, 9, "right", curses.color_pair(2))
+        stdscr.addstr(24, 9, "down", curses.color_pair(2))
         stdscr.addstr(24, 15, ":", curses.color_pair(1))
-        stdscr.addstr(24, 17, "Toggle selection on", curses.color_pair(3))
+        stdscr.addstr(24, 17, "Cycle down in selection", curses.color_pair(3))
 
-        stdscr.addstr(25, 9, "left", curses.color_pair(2))
+        stdscr.addstr(25, 9, "right", curses.color_pair(2))
         stdscr.addstr(25, 15, ":", curses.color_pair(1))
-        stdscr.addstr(25, 17, "Toggle selection off", curses.color_pair(3))
+        stdscr.addstr(25, 17, "Toggle selection on", curses.color_pair(3))
 
-        stdscr.addstr(26, 9, "space", curses.color_pair(2))
+        stdscr.addstr(26, 9, "left", curses.color_pair(2))
         stdscr.addstr(26, 15, ":", curses.color_pair(1))
-        stdscr.addstr(26, 17, "Cycle selection", curses.color_pair(3))
+        stdscr.addstr(26, 17, "Toggle selection off", curses.color_pair(3))
+
+        stdscr.addstr(27, 9, "space", curses.color_pair(2))
+        stdscr.addstr(27, 15, ":", curses.color_pair(1))
+        stdscr.addstr(27, 17, "Cycle selection", curses.color_pair(3))
 
     except Exception as e:
         eqa_settings.log(

--- a/eqa/lib/curses.py
+++ b/eqa/lib/curses.py
@@ -66,6 +66,8 @@ def display(stdscr, display_q, state, exit_flag):
                         zone = display_event.payload
                     elif display_event.screen == "char":
                         state.char = display_event.payload
+                    elif display_event.screen == "encounter":
+                        encounter_report = display_event.payload
                     draw_page(
                         stdscr,
                         page,

--- a/eqa/lib/curses.py
+++ b/eqa/lib/curses.py
@@ -45,11 +45,8 @@ def display(stdscr, display_q, state, exit_flag):
         while not exit_flag.is_set():
 
             # Sleep between empty checks
-            queue_size = display_q.qsize()
-            if queue_size < 2:
+            if display_q.qsize() < 1:
                 time.sleep(0.01)
-            else:
-                time.sleep(0.001)
 
             # Check queue for message
             if not display_q.empty():

--- a/eqa/lib/curses.py
+++ b/eqa/lib/curses.py
@@ -503,18 +503,47 @@ def draw_events_encounter(stdscr, encounter_report):
         center_y = int(y / 2)
         encounter_win_y = center_y - 4
         encounter_win_x = x - 4
+        mid_encounter_win_x = int(encounter_win_x / 2)
         encounterscr = stdscr.derwin(encounter_win_y, encounter_win_x, center_y + 3, 2)
         encounterscr.clear()
 
-        count = 1
+        # Center Line
+        center_line = 0
+        while center_line < encounter_win_y:
+            encounterscr.addch(center_line, mid_encounter_win_x, curses.ACS_VLINE)
+            center_line += 1
+
+        # Target Title
+        name_padding = int(mid_encounter_win_x / 2) - int(
+            len(encounter_report["target"]["name"]) / 2
+        )
+        encounterscr.addstr(
+            0, name_padding, encounter_report["target"]["name"], curses.color_pair(5)
+        )
+
+        # Target Underline
+        underline = 4
+        while underline < (mid_encounter_win_x - 4):
+            encounterscr.addch(1, underline, curses.ACS_HLINE, curses.color_pair(3))
+            underline += 1
+
+        # Target Mid-line
+        first_quarter = int(mid_encounter_win_x / 2)
+        midline = 2
+        while midline < (encounter_win_y - 6):
+            encounterscr.addch(midline, first_quarter, curses.ACS_VLINE, curses.color_pair(3))
+            midline += 1
+
+        # Target Stats
+        count = 2
         max_encounter_string_x = encounter_win_x - 34
         for entry in encounter_report["target"]:
-            encounterscr.addstr(count, 1, entry, curses.color_pair(3))
-            encounterscr.addch(count, 23, curses.ACS_VLINE)
-            encounterscr.addstr(
-                count, 25, encounter_report["target"][entry], curses.color_pair(1)
-            )
-            count += 1
+            if entry != "name":
+                encounterscr.addstr(count, 1, entry, curses.color_pair(3))
+                encounterscr.addstr(
+                    count, first_quarter + 2, encounter_report["target"][entry], curses.color_pair(1)
+                )
+                count += 1
 
     except Exception as e:
         eqa_settings.log(

--- a/eqa/lib/curses.py
+++ b/eqa/lib/curses.py
@@ -504,6 +504,7 @@ def draw_events_encounter(stdscr, encounter_report):
         encounter_win_y = center_y - 4
         encounter_win_x = x - 4
         mid_encounter_win_x = int(encounter_win_x / 2)
+        mid_encounter_win_y = int(encounter_win_y / 2)
         encounterscr = stdscr.derwin(encounter_win_y, encounter_win_x, center_y + 3, 2)
         encounterscr.clear()
 
@@ -530,30 +531,134 @@ def draw_events_encounter(stdscr, encounter_report):
         # Target Mid-line
         first_quarter = int(mid_encounter_win_x / 2)
         midline = 2
-        while midline < (encounter_win_y - 6):
-            encounterscr.addch(midline, first_quarter, curses.ACS_VLINE, curses.color_pair(3))
+        while midline < (encounter_win_y - 4):
+            encounterscr.addch(
+                midline, first_quarter, curses.ACS_VLINE, curses.color_pair(3)
+            )
             midline += 1
 
         # Target Stats
         count = 2
-        seven_g = int(first_quarter / 2)
         for entry in encounter_report["target"]:
-            if entry != "name" and not entry == "killed":
-                encounterscr.addstr(count, 1, entry.title(), curses.color_pair(5))
+            if entry != "name" and entry != "killed":
                 encounterscr.addstr(
-                    count, first_quarter + 2, str(encounter_report["target"][entry])[:seven_g].replace("_", " ").title(), curses.color_pair(1)
+                    count,
+                    1,
+                    str(entry.title())[:first_quarter].replace("_", " ").title(),
+                    curses.color_pair(5),
+                )
+                encounterscr.addstr(
+                    count,
+                    first_quarter + 2,
+                    str(encounter_report["target"][entry])[:first_quarter]
+                    .replace("_", " ")
+                    .title(),
+                    curses.color_pair(1),
                 )
                 count += 1
 
         # Participant Stats
         participant = 0
         third_quarter = first_quarter + mid_encounter_win_x
+        players = list(encounter_report["participants"].keys())
 
-        # P1 Underline
-        underline = mid_encounter_win_x - 2
-        while underline < (mid_encounter_win_x - 6):
-            encounterscr.addch(third_quarter, underline, curses.ACS_HLINE, curses.color_pair(3))
-            underline += 1
+        if len(players) > 0:
+
+            # Top P1 Title
+            name_padding = third_quarter - int(len(players[0]) / 2)
+            encounterscr.addstr(
+                0, name_padding, players[0].title(), curses.color_pair(5)
+            )
+
+            # Top P1 Underline
+            underline = mid_encounter_win_x + 4
+            while underline < (encounter_win_x - 4):
+                encounterscr.addch(1, underline, curses.ACS_HLINE, curses.color_pair(3))
+                underline += 1
+
+            # Top P1 Mid-line
+            midline = 2
+            while midline < (mid_encounter_win_y - 4):
+                encounterscr.addch(
+                    midline, third_quarter, curses.ACS_VLINE, curses.color_pair(3)
+                )
+                midline += 1
+
+            # Top P1 Stats
+            count = 2
+            for entry in encounter_report["participants"][players[0]]:
+                if count >= mid_encounter_win_y:
+                    break
+                encounterscr.addstr(
+                    count,
+                    mid_encounter_win_x + 2,
+                    str(entry)[:first_quarter].replace("_", " ").title(),
+                    curses.color_pair(5),
+                )
+                encounterscr.addstr(
+                    count,
+                    third_quarter + 2,
+                    str(encounter_report["participants"][players[0]][entry])[
+                        :first_quarter
+                    ]
+                    .replace("_", " ")
+                    .title(),
+                    curses.color_pair(1),
+                )
+                count += 1
+
+        if len(players) > 1:
+
+            # Top P2 Title
+            name_padding = third_quarter - int(len(players[1]) / 2)
+            encounterscr.addstr(
+                mid_encounter_win_y,
+                name_padding,
+                players[1].title(),
+                curses.color_pair(5),
+            )
+
+            # Top P2 Underline
+            underline = mid_encounter_win_x + 4
+            while underline < (encounter_win_x - 4):
+                encounterscr.addch(
+                    mid_encounter_win_y + 1,
+                    underline,
+                    curses.ACS_HLINE,
+                    curses.color_pair(3),
+                )
+                underline += 1
+
+            # Top P2 Mid-line
+            midline = mid_encounter_win_y + 2
+            while midline < (encounter_win_y - 4):
+                encounterscr.addch(
+                    midline, third_quarter, curses.ACS_VLINE, curses.color_pair(3)
+                )
+                midline += 1
+
+            # Top P2 Stats
+            count = mid_encounter_win_y + 2
+            for entry in encounter_report["participants"][players[1]]:
+                if count >= encounter_win_y - 1:
+                    break
+                encounterscr.addstr(
+                    count,
+                    mid_encounter_win_x + 2,
+                    str(entry)[:first_quarter].replace("_", " ").title(),
+                    curses.color_pair(5),
+                )
+                encounterscr.addstr(
+                    count,
+                    third_quarter + 2,
+                    str(encounter_report["participants"][players[1]][entry])[
+                        :first_quarter
+                    ]
+                    .replace("_", " ")
+                    .title(),
+                    curses.color_pair(1),
+                )
+                count += 1
 
     except Exception as e:
         eqa_settings.log(

--- a/eqa/lib/curses.py
+++ b/eqa/lib/curses.py
@@ -538,12 +538,22 @@ def draw_events_encounter(stdscr, encounter_report):
         count = 2
         seven_g = int(first_quarter / 2)
         for entry in encounter_report["target"]:
-            if entry != "name":
-                encounterscr.addstr(count, 1, entry.title(), curses.color_pair(3))
+            if entry != "name" and not entry == "killed":
+                encounterscr.addstr(count, 1, entry.title(), curses.color_pair(5))
                 encounterscr.addstr(
-                    count, first_quarter + 2, str(encounter_report["target"][entry])[:seven_g].title(), curses.color_pair(1)
+                    count, first_quarter + 2, str(encounter_report["target"][entry])[:seven_g].replace("_", " ").title(), curses.color_pair(1)
                 )
                 count += 1
+
+        # Participant Stats
+        participant = 0
+        third_quarter = first_quarter + mid_encounter_win_x
+
+        # P1 Underline
+        underline = mid_encounter_win_x - 2
+        while underline < (mid_encounter_win_x - 6):
+            encounterscr.addch(third_quarter, underline, curses.ACS_HLINE, curses.color_pair(3))
+            underline += 1
 
     except Exception as e:
         eqa_settings.log(

--- a/eqa/lib/curses.py
+++ b/eqa/lib/curses.py
@@ -541,7 +541,7 @@ def draw_events_encounter(stdscr, encounter_report):
 
         # Target Mid-line
         midline = 2
-        while midline < (encounter_win_y - 4):
+        while midline < (encounter_win_y - 1):
             encounterscr.addch(
                 midline, first_quarter, curses.ACS_VLINE, curses.color_pair(3)
             )

--- a/eqa/lib/curses.py
+++ b/eqa/lib/curses.py
@@ -527,9 +527,7 @@ def draw_events_encounter(stdscr, encounter_report):
             + " in "
             + encounter_report["encounter_summary"]["duration"]
         )
-        encounterscr.addstr(
-            0, name_padding, encounter_report["target"]["name"], curses.color_pair(5)
-        )
+        encounterscr.addstr(0, name_padding, target_title, curses.color_pair(5))
 
         # Target Underline
         first_quarter = int(mid_encounter_win_x / 2)
@@ -619,7 +617,8 @@ def draw_events_encounter(stdscr, encounter_report):
                 if "dps" in entry or "activity" in entry:
                     value = str(
                         format(
-                            float(encounter_report["participants"][players[0]][entry]), ".2f"
+                            float(encounter_report["participants"][players[0]][entry]),
+                            ".2f",
                         )
                     )
                 else:
@@ -685,7 +684,8 @@ def draw_events_encounter(stdscr, encounter_report):
                 if "dps" in entry or "activity" in entry:
                     value = str(
                         format(
-                            float(encounter_report["participants"][players[1]][entry]), ".2f"
+                            float(encounter_report["participants"][players[1]][entry]),
+                            ".2f",
                         )
                     )
                 else:

--- a/eqa/lib/curses.py
+++ b/eqa/lib/curses.py
@@ -734,7 +734,7 @@ def draw_ftime(stdscr, timestamp, y):
 def draw_parse(stdscr, state, encounter_report):
     """Draw parse"""
     y, x = stdscr.getmaxyx()
-    encounter_y = y - 4
+    encounter_y = int(y / 2) - 3
     encounter_x = x - 2
     center_y = int(encounter_y / 2)
     center_x = int(encounter_x / 2)
@@ -753,11 +753,15 @@ def draw_parse(stdscr, state, encounter_report):
     try:
         encounterscr = stdscr.derwin(encounter_y, encounter_x, 3, 1)
         encounterscr.clear()
+        playerscr = stdscr.derwin(int(y / 2) - 1, encounter_x, int(y / 2), 1)
+        playerscr.clear()
 
+        # If we're parsing encounters
         if state.encounter_parse == "true":
+            ## If we have a report to show
             if encounter_report is not None:
 
-                # Target Title
+                ### Target Title
                 encounterscr.addstr(
                     1,
                     1,
@@ -765,7 +769,7 @@ def draw_parse(stdscr, state, encounter_report):
                     curses.color_pair(2),
                 )
 
-                # Target Stats
+                ### Target Stats
                 count = 2
                 for entry in encounter_report["target"]:
                     if entry != "name" and entry != "killed":
@@ -791,7 +795,7 @@ def draw_parse(stdscr, state, encounter_report):
                         )
                         count += 1
 
-                    # Killed
+                    #### Killed
                     elif entry == "killed":
                         encounterscr.addstr(
                             1,
@@ -815,7 +819,7 @@ def draw_parse(stdscr, state, encounter_report):
                             )
                             kill_count += 1
 
-                # Encounter Summary
+                ### Encounter Summary
                 encounterscr.addstr(
                     1,
                     center_x,
@@ -832,7 +836,9 @@ def draw_parse(stdscr, state, encounter_report):
                     )
                     if entry == "location":
                         value = re.sub(
-                            r"[^\d+\.\,\-\s]", "", encounter_report["encounter_summary"][entry]
+                            r"[^\d+\.\,\-\s]",
+                            "",
+                            encounter_report["encounter_summary"][entry],
                         )
                     else:
                         value = encounter_report["encounter_summary"][entry]
@@ -843,13 +849,65 @@ def draw_parse(stdscr, state, encounter_report):
                         curses.color_pair(1),
                     )
                     count += 1
+
+                ### Player Summary
+                playerscr.addstr(
+                    0, int(encounter_x / 2) - 4, "Players:", curses.color_pair(2)
+                )
+                player_x = 1
+                player_y = 1
+                for player in encounter_report["participants"].keys():
+                    playerscr.addstr(
+                        player_y, player_x, player.title() + ":", curses.color_pair(3)
+                    )
+                    player_y += 1
+                    for stat in encounter_report["participants"][player].keys():
+                        playerscr.addstr(
+                            player_y,
+                            player_x + 2,
+                            stat[:first_quarter].title().replace("_", " "),
+                            curses.color_pair(5),
+                        )
+                        if "dps" in stat or "activity" in stat:
+                            value = str(
+                                format(
+                                    float(
+                                        encounter_report["participants"][player][stat]
+                                    ),
+                                    ".2f",
+                                )
+                            )
+                        else:
+                            value = str(encounter_report["participants"][player][stat])
+                        playerscr.addstr(
+                            player_y,
+                            player_x + 22,
+                            value[:first_quarter].title().replace("_", " "),
+                            curses.color_pair(1),
+                        )
+                        player_y += 1
+                    if player_y > (int(y / 2) - 10):
+                        player_y = 1
+                        if player_x <= second_third:
+                            player_x += first_third
+                        else:
+                            # We're out of screen space
+                            break
+                    else:
+                        player_y += 1
             else:
                 encounterscr.addstr(
-                    5, 5, "no encounter parse yet", curses.color_pair(2)
+                    center_y,
+                    center_x - 11,
+                    "no encounter parse yet",
+                    curses.color_pair(2),
                 )
         else:
             encounterscr.addstr(
-                5, 5, "encounter parsing disabled", curses.color_pair(2)
+                center_y,
+                center_x - 13,
+                "encounter parsing disabled",
+                curses.color_pair(2),
             )
 
     except Exception as e:

--- a/eqa/lib/curses.py
+++ b/eqa/lib/curses.py
@@ -193,6 +193,7 @@ def init(state):
         curses.init_pair(3, curses.COLOR_CYAN, -1)  # Subtext
         curses.init_pair(4, curses.COLOR_MAGENTA, -1)  # Highlight
         curses.init_pair(5, curses.COLOR_GREEN, -1)  # Dunno
+        curses.init_pair(6, curses.COLOR_RED, -1)  # Dunno
         draw_events_frame(stdscr, state, [], [], None)
         return stdscr
 
@@ -515,8 +516,16 @@ def draw_events_encounter(stdscr, encounter_report):
             center_line += 1
 
         # Target Title
-        name_padding = int(mid_encounter_win_x / 2) - int(
-            len(encounter_report["target"]["name"]) / 2
+        name_padding = (
+            int(mid_encounter_win_x / 2)
+            - int(len(encounter_report["target"]["name"]) / 2)
+            - len(encounter_report["encounter_summary"]["duration"])
+            - 2
+        )
+        target_title = (
+            encounter_report["target"]["name"]
+            + " in "
+            + encounter_report["encounter_summary"]["duration"]
         )
         encounterscr.addstr(
             0, name_padding, encounter_report["target"]["name"], curses.color_pair(5)
@@ -546,16 +555,18 @@ def draw_events_encounter(stdscr, encounter_report):
             if entry != "name" and entry != "killed":
                 encounterscr.addstr(
                     count,
-                    1,
+                    4,
                     str(entry.title())[:first_quarter].replace("_", " ").title(),
                     curses.color_pair(5),
                 )
+                if "dps" in entry or "activity" in entry:
+                    value = str(format(float(encounter_report["target"][entry]), ".2f"))
+                else:
+                    value = str(encounter_report["target"][entry])
                 encounterscr.addstr(
                     count,
                     first_quarter + 2,
-                    str(encounter_report["target"][entry])[:first_quarter]
-                    .replace("_", " ")
-                    .title(),
+                    value[:first_quarter].replace("_", " ").title(),
                     curses.color_pair(1),
                 )
                 count += 1
@@ -601,18 +612,22 @@ def draw_events_encounter(stdscr, encounter_report):
                     break
                 encounterscr.addstr(
                     count,
-                    mid_encounter_win_x + 2,
+                    mid_encounter_win_x + 4,
                     str(entry)[:first_quarter].replace("_", " ").title(),
                     curses.color_pair(5),
                 )
+                if "dps" in entry or "activity" in entry:
+                    value = str(
+                        format(
+                            float(encounter_report["participants"][players[0]][entry]), ".2f"
+                        )
+                    )
+                else:
+                    value = str(encounter_report["participants"][players[0]][entry])
                 encounterscr.addstr(
                     count,
                     third_quarter + 2,
-                    str(encounter_report["participants"][players[0]][entry])[
-                        :first_quarter
-                    ]
-                    .replace("_", " ")
-                    .title(),
+                    str(value)[:first_quarter].replace("_", " ").title(),
                     curses.color_pair(1),
                 )
                 count += 1
@@ -663,18 +678,22 @@ def draw_events_encounter(stdscr, encounter_report):
                     break
                 encounterscr.addstr(
                     count,
-                    mid_encounter_win_x + 2,
+                    mid_encounter_win_x + 4,
                     str(entry)[:first_quarter].replace("_", " ").title(),
                     curses.color_pair(5),
                 )
+                if "dps" in entry or "activity" in entry:
+                    value = str(
+                        format(
+                            float(encounter_report["participants"][players[1]][entry]), ".2f"
+                        )
+                    )
+                else:
+                    value = str(encounter_report["participants"][players[1]][entry])
                 encounterscr.addstr(
                     count,
                     third_quarter + 2,
-                    str(encounter_report["participants"][players[1]][entry])[
-                        :first_quarter
-                    ]
-                    .replace("_", " ")
-                    .title(),
+                    value[:first_quarter].replace("_", " ").title(),
                     curses.color_pair(1),
                 )
                 count += 1

--- a/eqa/lib/curses.py
+++ b/eqa/lib/curses.py
@@ -523,13 +523,16 @@ def draw_events_encounter(stdscr, encounter_report):
         )
 
         # Target Underline
+        first_quarter = int(mid_encounter_win_x / 2)
         underline = 4
         while underline < (mid_encounter_win_x - 4):
-            encounterscr.addch(1, underline, curses.ACS_HLINE, curses.color_pair(3))
+            if underline == first_quarter:
+                encounterscr.addch(1, underline, curses.ACS_TTEE, curses.color_pair(3))
+            else:
+                encounterscr.addch(1, underline, curses.ACS_HLINE, curses.color_pair(3))
             underline += 1
 
         # Target Mid-line
-        first_quarter = int(mid_encounter_win_x / 2)
         midline = 2
         while midline < (encounter_win_y - 4):
             encounterscr.addch(
@@ -573,12 +576,19 @@ def draw_events_encounter(stdscr, encounter_report):
             # Top P1 Underline
             underline = mid_encounter_win_x + 4
             while underline < (encounter_win_x - 4):
-                encounterscr.addch(1, underline, curses.ACS_HLINE, curses.color_pair(3))
+                if underline == third_quarter:
+                    encounterscr.addch(
+                        1, underline, curses.ACS_TTEE, curses.color_pair(3)
+                    )
+                else:
+                    encounterscr.addch(
+                        1, underline, curses.ACS_HLINE, curses.color_pair(3)
+                    )
                 underline += 1
 
             # Top P1 Mid-line
             midline = 2
-            while midline < (mid_encounter_win_y - 4):
+            while midline < (mid_encounter_win_y - 1):
                 encounterscr.addch(
                     midline, third_quarter, curses.ACS_VLINE, curses.color_pair(3)
                 )
@@ -621,17 +631,26 @@ def draw_events_encounter(stdscr, encounter_report):
             # Top P2 Underline
             underline = mid_encounter_win_x + 4
             while underline < (encounter_win_x - 4):
-                encounterscr.addch(
-                    mid_encounter_win_y + 1,
-                    underline,
-                    curses.ACS_HLINE,
-                    curses.color_pair(3),
-                )
+                if underline == third_quarter:
+                    pass
+                    encounterscr.addch(
+                        mid_encounter_win_y + 1,
+                        underline,
+                        curses.ACS_TTEE,
+                        curses.color_pair(3),
+                    )
+                else:
+                    encounterscr.addch(
+                        mid_encounter_win_y + 1,
+                        underline,
+                        curses.ACS_HLINE,
+                        curses.color_pair(3),
+                    )
                 underline += 1
 
             # Top P2 Mid-line
             midline = mid_encounter_win_y + 2
-            while midline < (encounter_win_y - 4):
+            while midline < (encounter_win_y - 1):
                 encounterscr.addch(
                     midline, third_quarter, curses.ACS_VLINE, curses.color_pair(3)
                 )

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -1305,7 +1305,7 @@ def encounter_report(
             )
 
             ## Determine Encounter Duration
-            ### Tragically this cuts off milliseconds, for now
+            ### Find end time
             found_time = False
             (
                 last_time,
@@ -1319,6 +1319,8 @@ def encounter_report(
             encounter_end_time = datetime(
                 2020, 12, 30, int(last_hour), int(last_minute), int(last_second)
             )
+
+            ## Find start time and build this_encounter
             for event in encounter_stack:
                 time, source, target, mode, result = event
                 if (
@@ -1347,7 +1349,6 @@ def encounter_report(
                     )
                     this_encounter.append((time, source, target, mode, result))
                     encounter_stack.remove(event)
-                ### Build list of events after first encounter, remove them from encounter_stack
                 elif (
                     found_time
                     and source == encounter_target
@@ -1364,6 +1365,7 @@ def encounter_report(
             encounter_duration = int(
                 (encounter_end_time - encounter_start_time).total_seconds()
             )
+            ### Spot check duration weirdness over midnight
             if int(encounter_duration) < 0:
                 first_half = (
                     datetime(2020, 12, 30, 23, 59, 59) - encounter_start_time

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -94,6 +94,16 @@ def process(
                                     config,
                                     display_q,
                                 )
+                            else:
+                                encounter_stack.append(
+                                    (
+                                        line_time,
+                                        source.title(),
+                                        target.title(),
+                                        "slain",
+                                        "other",
+                                    )
+                                )
                         else:
                             encounter_report(
                                 line_type,
@@ -1401,6 +1411,8 @@ def encounter_report(
             encounter_activity = {}
             encounter_heals = {}
             encounter_casts = {}
+            target_killed = {}
+            killed_by_target = {}
 
             for event in this_encounter:
                 time, source, target, mode, result = event
@@ -1541,6 +1553,12 @@ def encounter_report(
                         encounter_heals[source] = int(result)
                     else:
                         encounter_heals[source] += int(results)
+                ### If mode is slain
+                elif mode == "slain":
+                    if target not in target_killed.keys():
+                        target_killed[target] = 1
+                    else:
+                        target_killed[target] += 1
 
             ## Sort Encounter Activity from Most to Least Active
             sorted_encounter_activity = dict(
@@ -1692,6 +1710,13 @@ def encounter_report(
                 encounter_report["target"]["spell_casts"] = str(
                     encounter_casts[encounter_target]
                 )
+            if target_killed:
+                encounter_report["target"]["killed"] = {}
+                for victim in target_killed.keys():
+                    v_low = victim.lower()
+                    encounter_report["target"]["killed"][v_low] = str(
+                        target_killed[victim]
+                    )
 
             ### Encounter Participants
             for participant in sorted_encounter_activity.keys():
@@ -1768,6 +1793,10 @@ def encounter_report(
                     if participant in encounter_heals.keys():
                         encounter_report["participants"][l_part]["healing"] = str(
                             encounter_heals.get(participant)
+                        )
+                    if participant in target_killed.keys():
+                        encounter_report["participants"][l_part]["killed"] = str(
+                            target_killed.keys
                         )
 
             ## Send Report to Display

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -70,7 +70,6 @@ def process(
                         or line_type == "spell_damage"
                         or line_type == "spell_resist_you"
                         or line_type == "you_auto_attack_on"
-                        or line_type == "you_auto_attack_off"
                     ):
                         #### Set active encounter
                         active_encounter = True

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -60,7 +60,7 @@ def process(
 
                 ## Check for encounter_stack clear
                 if interaction == "clear":
-                    encounter_stack = []
+                    encounter_stack.clear()
 
                 ## If not an active encounter
                 if active_encounter == False:

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -42,7 +42,6 @@ def process(
 
     encounter_stack = []
     active_encounter = False
-    detect_encounter = True
 
     try:
         while not exit_flag.is_set() and not cfg_reload.is_set():

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -1569,15 +1569,16 @@ def encounter_report(
             ## Build Encounter Report
             ### Encounter Summary
             encounter_report = {
+                "header": {},
                 "encounter_summary": {},
                 "target": {},
                 "participants": {},
             }
-            encounter_report["encounter_summary"]["version"] = str(
+            encounter_report["header"]["version"] = str(
                 pkg_resources.get_distribution("eqalert").version
             )
-            encounter_report["encounter_summary"]["date"] = str(encounter_parse_date)
-            encounter_report["encounter_summary"]["time"] = str(encounter_parse_time)
+            encounter_report["header"]["date"] = str(encounter_parse_date)
+            encounter_report["header"]["time"] = str(encounter_parse_time)
             encounter_report["encounter_summary"]["character"] = str(state.char)
             encounter_report["encounter_summary"]["server"] = str(state.server)
             encounter_report["encounter_summary"]["zone"] = str(state.zone)

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -1555,10 +1555,11 @@ def encounter_report(
                         encounter_heals[source] += int(results)
                 ### If mode is slain
                 elif mode == "slain":
-                    if target not in target_killed.keys():
-                        target_killed[target] = 1
-                    else:
-                        target_killed[target] += 1
+                    if source == encounter_target:
+                        if target not in target_killed.keys():
+                            target_killed[target] = 1
+                        else:
+                            target_killed[target] += 1
 
             ## Sort Encounter Activity from Most to Least Active
             sorted_encounter_activity = dict(

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -1,0 +1,1278 @@
+#! /usr/bin/env python
+
+"""
+   Program:   EQ Alert
+   File Name: eqa/lib/encounter.py
+   Copyright (C) 2022 Michael Geitz
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+   Parse and react to eqemu logs
+"""
+
+import re
+import sys
+import time
+
+import eqa.lib.settings as eqa_settings
+
+
+def process(
+    config, base_path, encounter_q, system_q, display_q, exit_flag, cfg_reload, state
+):
+    """
+    Process: encounter_q
+    Produce: display_q, system_q
+    """
+
+    encounter_stack = []
+    active_encounter = False
+    detect_encounter = True
+
+    try:
+        while not exit_flag.is_set() and not cfg_reload.is_set():
+
+            # Sleep between empty checks
+            if encounter_q.qsize() < 1:
+                time.sleep(0.01)
+
+            # Check queue for message
+            if not encounter_q.empty():
+                new_message = encounter_q.get()
+                line_type = new_message.type
+                line_time = new_message.timestamp
+                interaction = new_message.tx
+                line = new_message.payload
+
+                if active_encounter == False:
+                    if (
+                        interaction == "combat"
+                        or line_type == "spell_damage"
+                        or line_type == "spell_resist_you"
+                        or line_type == "you_auto_attack_on"
+                        or line_type == "you_auto_attack_off"
+                        or line_type == "engage"
+                    ):
+                        active_encounter = True
+                else:
+                    if interaction == "stop" or line_type == "you_new_zone":
+                        active_encounter = False
+                        encounter_report(
+                            line_type, line_time, line, encounter_stack, state
+                        )
+                        encounter_stack.clear()
+
+                if active_encounter == True:
+                    if interaction == "combat":
+                        encounter_combat(
+                            line_type, line_time, line, encounter_stack, state
+                        )
+                    elif interaction == "spell":
+                        encounter_spell(
+                            line_type, line_time, line, encounter_stack, state
+                        )
+
+                encounter_q.task_done()
+
+        sys.exit(0)
+
+    except Exception as e:
+        eqa_settings.log(
+            "encounter: Error on line "
+            + str(sys.exc_info()[-1].tb_lineno)
+            + ": "
+            + str(e)
+        )
+
+
+def encounter_combat(line_type, line_time, line, encounter_stack, state):
+    """Handle combat lines for encounters"""
+
+    try:
+
+        source = None
+        target = None
+        mode = None
+        result = None
+
+        if line_type == "combat_other_melee":
+            mode = "damage"
+            if " mauls " in line:
+                source, sans_source = line.split(" mauls ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+            elif " hits " in line:
+                source, sans_source = line.split(" hits ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+            elif " crushes " in line:
+                source, sans_source = line.split(" crushes ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+            elif " slashes " in line:
+                source, sans_source = line.split(" slashes ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+            elif " pierces " in line:
+                source, sans_source = line.split(" pierces ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+            elif " bashes " in line:
+                source, sans_source = line.split(" bashes ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+            elif " backstabs " in line:
+                source, sans_source = line.split(" backstabs ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+            elif " bites " in line:
+                source, sans_source = line.split(" bites ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+            elif " kicks " in line:
+                source, sans_source = line.split(" kicks ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+            elif " claws " in line:
+                source, sans_source = line.split(" claws ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+            elif " gores " in line:
+                source, sans_source = line.split(" gores ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+            elif " punches " in line:
+                source, sans_source = line.split(" punches ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+            elif " strikes " in line:
+                source, sans_source = line.split(" strikes ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+            elif " slices " in line:
+                source, sans_source = line.split(" slices ")
+                target, extra = sans_source.split(" for ")
+                if target == "YOU":
+                    target = state.char
+                result = extra.split(" ")[0]
+        elif line_type == "combat_other_melee_block":
+            mode = "damage"
+            if " tries to maul " in line:
+                source, sans_source = line.split(" tries to maul ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+            elif " tries to hit " in line:
+                source, sans_source = line.split(" tries to hit ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+            elif " tries to crush " in line:
+                source, sans_source = line.split(" tries to crush ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+            elif " tries to slash " in line:
+                source, sans_source = line.split(" tries to slash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+            elif " tries to pierce " in line:
+                source, sans_source = line.split(" tries to pierce ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+            elif " tries to bash " in line:
+                source, sans_source = line.split(" tries to bash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+            elif " tries to backstab " in line:
+                source, sans_source = line.split(" tries to backstab ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+            elif " tries to bite " in line:
+                source, sans_source = line.split(" tries to bite ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+            elif " tries to kick " in line:
+                source, sans_source = line.split(" tries to kick ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+            elif " tries to claw " in line:
+                source, sans_source = line.split(" tries to claw ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+            elif " tries to gore " in line:
+                source, sans_source = line.split(" tries to gore ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+            elif " tries to punch " in line:
+                source, sans_source = line.split(" tries to punch ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+            elif " tries to strike " in line:
+                source, sans_source = line.split(" tries to strike ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+            elif " tries to slice " in line:
+                source, sans_source = line.split(" tries to slice ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "block"
+        elif line_type == "combat_other_melee_crip_blow":
+            pass
+        elif line_type == "combat_other_melee_crit":
+            pass
+        elif line_type == "combat_other_melee_crit_kick":
+            pass
+        elif line_type == "you_auto_attack_off":
+            pass
+        elif line_type == "you_auto_attack_on":
+            pass
+        elif line_type == "engage":
+            pass
+        elif line_type == "combat_other_melee_dodge":
+            mode = "damage"
+            if " tries to maul " in line:
+                source, sans_source = line.split(" tries to maul ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+            elif " tries to hit " in line:
+                source, sans_source = line.split(" tries to hit ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+            elif " tries to crush " in line:
+                source, sans_source = line.split(" tries to crush ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+            elif " tries to slash " in line:
+                source, sans_source = line.split(" tries to slash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+            elif " tries to pierce " in line:
+                source, sans_source = line.split(" tries to pierce ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+            elif " tries to bash " in line:
+                source, sans_source = line.split(" tries to bash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+            elif " tries to backstab " in line:
+                source, sans_source = line.split(" tries to backstab ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+            elif " tries to bite " in line:
+                source, sans_source = line.split(" tries to bite ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+            elif " tries to kick " in line:
+                source, sans_source = line.split(" tries to kick ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+            elif " tries to claw " in line:
+                source, sans_source = line.split(" tries to claw ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+            elif " tries to gore " in line:
+                source, sans_source = line.split(" tries to gore ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+            elif " tries to punch " in line:
+                source, sans_source = line.split(" tries to punch ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+            elif " tries to strike " in line:
+                source, sans_source = line.split(" tries to strike ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+            elif " tries to slice " in line:
+                source, sans_source = line.split(" tries to slice ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "dodge"
+        elif line_type == "combat_other_melee_invulnerable":
+            mode = "damage"
+            if " tries to maul " in line:
+                source, sans_source = line.split(" tries to maul ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+            elif " tries to hit " in line:
+                source, sans_source = line.split(" tries to hit ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+            elif " tries to crush " in line:
+                source, sans_source = line.split(" tries to crush ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+            elif " tries to slash " in line:
+                source, sans_source = line.split(" tries to slash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+            elif " tries to pierce " in line:
+                source, sans_source = line.split(" tries to pierce ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+            elif " tries to bash " in line:
+                source, sans_source = line.split(" tries to bash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+            elif " tries to backstab " in line:
+                source, sans_source = line.split(" tries to backstab ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+            elif " tries to bite " in line:
+                source, sans_source = line.split(" tries to bite ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+            elif " tries to kick " in line:
+                source, sans_source = line.split(" tries to kick ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+            elif " tries to claw " in line:
+                source, sans_source = line.split(" tries to claw ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+            elif " tries to gore " in line:
+                source, sans_source = line.split(" tries to gore ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+            elif " tries to punch " in line:
+                source, sans_source = line.split(" tries to punch ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+            elif " tries to strike " in line:
+                source, sans_source = line.split(" tries to strike ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+            elif " tries to slice " in line:
+                source, sans_source = line.split(" tries to slice ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "invulnerable"
+        elif line_type == "combat_other_melee_miss":
+            mode = "damage"
+            if " tries to maul " in line:
+                source, sans_source = line.split(" tries to maul ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+            elif " tries to hit " in line:
+                source, sans_source = line.split(" tries to hit ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+            elif " tries to crush " in line:
+                source, sans_source = line.split(" tries to crush ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+            elif " tries to slash " in line:
+                source, sans_source = line.split(" tries to slash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+            elif " tries to pierce " in line:
+                source, sans_source = line.split(" tries to pierce ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+            elif " tries to bash " in line:
+                source, sans_source = line.split(" tries to bash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+            elif " tries to backstab " in line:
+                source, sans_source = line.split(" tries to backstab ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+            elif " tries to bite " in line:
+                source, sans_source = line.split(" tries to bite ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+            elif " tries to kick " in line:
+                source, sans_source = line.split(" tries to kick ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+            elif " tries to claw " in line:
+                source, sans_source = line.split(" tries to claw ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+            elif " tries to gore " in line:
+                source, sans_source = line.split(" tries to gore ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+            elif " tries to punch " in line:
+                source, sans_source = line.split(" tries to punch ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+            elif " tries to strike " in line:
+                source, sans_source = line.split(" tries to strike ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+            elif " tries to slice " in line:
+                source, sans_source = line.split(" tries to slice ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "miss"
+        elif line_type == "combat_other_melee_parry":
+            mode = "damage"
+            if " tries to maul " in line:
+                source, sans_source = line.split(" tries to maul ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+            elif " tries to hit " in line:
+                source, sans_source = line.split(" tries to hit ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+            elif " tries to crush " in line:
+                source, sans_source = line.split(" tries to crush ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+            elif " tries to slash " in line:
+                source, sans_source = line.split(" tries to slash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+            elif " tries to pierce " in line:
+                source, sans_source = line.split(" tries to pierce ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+            elif " tries to bash " in line:
+                source, sans_source = line.split(" tries to bash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+            elif " tries to backstab " in line:
+                source, sans_source = line.split(" tries to backstab ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+            elif " tries to bite " in line:
+                source, sans_source = line.split(" tries to bite ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+            elif " tries to kick " in line:
+                source, sans_source = line.split(" tries to kick ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+            elif " tries to claw " in line:
+                source, sans_source = line.split(" tries to claw ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+            elif " tries to gore " in line:
+                source, sans_source = line.split(" tries to gore ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+            elif " tries to punch " in line:
+                source, sans_source = line.split(" tries to punch ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+            elif " tries to strike " in line:
+                source, sans_source = line.split(" tries to strike ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+            elif " tries to slice " in line:
+                source, sans_source = line.split(" tries to slice ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "parry"
+        elif line_type == "combat_other_melee_reposte":
+            mode = "damage"
+            if " tries to maul " in line:
+                source, sans_source = line.split(" tries to maul ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+            elif " tries to hit " in line:
+                source, sans_source = line.split(" tries to hit ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+            elif " tries to crush " in line:
+                source, sans_source = line.split(" tries to crush ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+            elif " tries to slash " in line:
+                source, sans_source = line.split(" tries to slash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+            elif " tries to pierce " in line:
+                source, sans_source = line.split(" tries to pierce ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+            elif " tries to bash " in line:
+                source, sans_source = line.split(" tries to bash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+            elif " tries to backstab " in line:
+                source, sans_source = line.split(" tries to backstab ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+            elif " tries to bite " in line:
+                source, sans_source = line.split(" tries to bite ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+            elif " tries to kick " in line:
+                source, sans_source = line.split(" tries to kick ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+            elif " tries to claw " in line:
+                source, sans_source = line.split(" tries to claw ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+            elif " tries to gore " in line:
+                source, sans_source = line.split(" tries to gore ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+            elif " tries to punch " in line:
+                source, sans_source = line.split(" tries to punch ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+            elif " tries to strike " in line:
+                source, sans_source = line.split(" tries to strike ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+            elif " tries to slice " in line:
+                source, sans_source = line.split(" tries to slice ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "riposte"
+        elif line_type == "combat_other_rune_damage":
+            mode = "damage"
+            if " tries to maul " in line:
+                source, sans_source = line.split(" tries to maul ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+            elif " tries to hit " in line:
+                source, sans_source = line.split(" tries to hit ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+            elif " tries to crush " in line:
+                source, sans_source = line.split(" tries to crush ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+            elif " tries to slash " in line:
+                source, sans_source = line.split(" tries to slash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+            elif " tries to pierce " in line:
+                source, sans_source = line.split(" tries to pierce ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+            elif " tries to bash " in line:
+                source, sans_source = line.split(" tries to bash ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+            elif " tries to backstab " in line:
+                source, sans_source = line.split(" tries to backstab ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+            elif " tries to bite " in line:
+                source, sans_source = line.split(" tries to bite ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+            elif " tries to kick " in line:
+                source, sans_source = line.split(" tries to kick ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+            elif " tries to claw " in line:
+                source, sans_source = line.split(" tries to claw ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+            elif " tries to gore " in line:
+                source, sans_source = line.split(" tries to gore ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+            elif " tries to punch " in line:
+                source, sans_source = line.split(" tries to punch ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+            elif " tries to strike " in line:
+                source, sans_source = line.split(" tries to strike ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+            elif " tries to slice " in line:
+                source, sans_source = line.split(" tries to slice ")
+                target, extra = sans_source.split(",")
+                if target == "YOU":
+                    target = state.char
+                result = "rune"
+        elif line_type == "combat_you_melee":
+            mode = "damage"
+            if " maul " in line:
+                source, sans_source = line.split(" maul ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+            elif " hit " in line:
+                source, sans_source = line.split(" hit ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+            elif " crush " in line:
+                source, sans_source = line.split(" crush ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+            elif " slash " in line:
+                source, sans_source = line.split(" slash ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+            elif " pierce " in line:
+                source, sans_source = line.split(" pierce ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+            elif " bash " in line:
+                source, sans_source = line.split(" bash ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+            elif " backstab " in line:
+                source, sans_source = line.split(" backstab ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+            elif " bite " in line:
+                source, sans_source = line.split(" bite ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+            elif " kick " in line:
+                source, sans_source = line.split(" kick ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+            elif " claw " in line:
+                source, sans_source = line.split(" claw ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+            elif " gore " in line:
+                source, sans_source = line.split(" gore ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+            elif " punch " in line:
+                source, sans_source = line.split(" punch ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+            elif " strike " in line:
+                source, sans_source = line.split(" strike ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+            elif " slice " in line:
+                source, sans_source = line.split(" slice ")
+                source = state.char
+                target, extra = sans_source.split(" for ")
+                result = extra.split(" ")[0]
+        elif line_type == "combat_you_melee_miss":
+            mode = "damage"
+            if " try to maul " in line:
+                source, sans_source = line.split(" try to maul ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+            elif " try to hit " in line:
+                source, sans_source = line.split(" try to hit ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+            elif " try to crush " in line:
+                source, sans_source = line.split(" try to crush ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+            elif " try to slash " in line:
+                source, sans_source = line.split(" try to slash ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+            elif " try to pierce " in line:
+                source, sans_source = line.split(" try to pierce ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+            elif " try to bash " in line:
+                source, sans_source = line.split(" try to bash ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+            elif " try to backstab " in line:
+                source, sans_source = line.split(" try to backstab ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+            elif " try to bite " in line:
+                source, sans_source = line.split(" try to bite ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+            elif " try to kick " in line:
+                source, sans_source = line.split(" try to kick ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+            elif " try to claw " in line:
+                source, sans_source = line.split(" try to claw ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+            elif " try to gore " in line:
+                source, sans_source = line.split(" try to gore ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+            elif " try to punch " in line:
+                source, sans_source = line.split(" try to punch ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+            elif " try to strike " in line:
+                source, sans_source = line.split(" try to strike ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+            elif " try to slice " in line:
+                source, sans_source = line.split(" try to slice ")
+                source = state.char
+                target, extra = sans_source.split(",")
+                result = "miss"
+        elif line_type == "combat_you_receive_melee":
+            mode = "damage"
+            if " mauls " in line:
+                source, sans_source = line.split(" mauls ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+            elif " hits " in line:
+                source, sans_source = line.split(" hits ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+            elif " crushes " in line:
+                source, sans_source = line.split(" crushes ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+            elif " slashes " in line:
+                source, sans_source = line.split(" slashes ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+            elif " pierces " in line:
+                source, sans_source = line.split(" pierces ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+            elif " bashes " in line:
+                source, sans_source = line.split(" bashes ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+            elif " backstabs " in line:
+                source, sans_source = line.split(" backstabs ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+            elif " bites " in line:
+                source, sans_source = line.split(" bites ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+            elif " kicks " in line:
+                source, sans_source = line.split(" kicks ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+            elif " claws " in line:
+                source, sans_source = line.split(" claws ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+            elif " gores " in line:
+                source, sans_source = line.split(" gores ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+            elif " punches " in line:
+                source, sans_source = line.split(" punches ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+            elif " strikes " in line:
+                source, sans_source = line.split(" strikes ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+            elif " slices " in line:
+                source, sans_source = line.split(" slices ")
+                target, extra = sans_source.split(" for ")
+                target = state.char
+                result = extra.split(" ")[0]
+
+        # Add to encounter stack
+        if (
+            source is not None
+            and target is not None
+            and mode is not None
+            and result is not None
+        ):
+            encounter_stack.append(
+                (line_time, source.title(), target.title(), mode, result)
+            )
+        elif state.debug == "true":
+            eqa_settings.log(
+                "encounter combat ["
+                + line_type
+                + "] not added to encounter stack: "
+                + line
+            )
+
+    except Exception as e:
+        eqa_settings.log(
+            "encounter combat: Error on line "
+            + str(sys.exc_info()[-1].tb_lineno)
+            + ": "
+            + str(e)
+        )
+
+
+def encounter_spell(line_type, line_time, line, encounter_stack, state):
+    """Handle spell lines for encounters"""
+
+    try:
+        source = None
+        target = None
+        mode = None
+        result = None
+
+        if line_type == "spell_heal_you":
+            mode = "heal"
+            source, sans_source = line.split(" have healed ")
+            source = state.char
+            target, extra = sans_source.split(" for ")
+            result = extra.split(" ")[0]
+        elif line_type == "spell_cast_other":
+            pass
+        elif line_type == "spell_cast_you":
+            pass
+        elif line_type == "spell_cast_item_you":
+            pass
+        elif line_type == "spell_fizzle_other":
+            pass
+        elif line_type == "spell_fizzle_you":
+            pass
+        elif line_type == "spell_not_hold":
+            pass
+        elif line_type == "spell_cast_oom":
+            pass
+        elif line_type == "spell_interrupt_other":
+            pass
+        elif line_type == "spell_interrupt_you":
+            pass
+        elif line_type == "spell_recover_other":
+            pass
+        elif line_type == "spell_recover_you":
+            pass
+        elif line_type == "spell_resist_you":
+            pass
+        elif line_type == "spell_damage":
+            mode = "spell"
+            if "was" in line:
+                source = state.char
+                target, sans_target = line.split(" was ")
+                result = re.findall(r"\d+", line)[0]
+            elif "were" in line:
+                source = "unknown"
+                target = state.char
+                result = re.findall(r"\d+", line)[0]
+        elif line_type == "spell_memorize_begin":
+            pass
+        elif line_type == "spell_memorize_finish":
+            pass
+        elif line_type == "spell_memorize_already":
+            pass
+        elif line_type == "spell_forget":
+            pass
+        elif line_type == "spell_worn_off":
+            pass
+        elif line_type == "spell_protected":
+            pass
+        elif line_type == "spell_cooldown_active":
+            pass
+        elif line_type == "spell_sitting":
+            pass
+        elif line_type == "spell_no_target":
+            pass
+        elif line_type == "spell_regen_on_other":
+            pass
+        elif line_type == "spell_regen_on_you":
+            pass
+        elif line_type == "spell_sow_on_you":
+            pass
+        elif line_type == "spell_sow_off_you":
+            pass
+        elif line_type == "spell_invis_on_you":
+            pass
+        elif line_type == "spell_invis_off_you":
+            pass
+        elif line_type == "spell_invis_dropping_you":
+            pass
+        elif line_type == "spell_levitate_on_you":
+            pass
+        elif line_type == "spell_levitate_dropping_you":
+            pass
+        elif line_type == "spell_levitate_off_you":
+            pass
+        elif line_type == "spell_cured_other":
+            pass
+        elif line_type == "spell_summoned_you":
+            pass
+        elif line_type == "spell_slow_on":
+            pass
+        elif line_type == "spell_bind_you":
+            pass
+        elif line_type == "spell_gate_collapse":
+            pass
+
+        # Add to encounter stack
+        if (
+            source is not None
+            and target is not None
+            and mode is not None
+            and result is not None
+        ):
+            encounter_stack.append(
+                (line_time, source.title(), target.title(), mode, result)
+            )
+        elif state.debug == "true":
+            eqa_settings.log(
+                "encounter spell ["
+                + line_type
+                + "] not added to encounter stack: "
+                + line
+            )
+
+    except Exception as e:
+        eqa_settings.log(
+            "encounter spell: Error on line "
+            + str(sys.exc_info()[-1].tb_lineno)
+            + ": "
+            + str(e)
+        )
+
+
+def encounter_report(line_type, line_time, line, encounter_stack, state):
+    """Report encounter stats"""
+
+    try:
+
+        eqa_settings.log("--- encounter stack contents ---")
+        eqa_settings.log("Total events: " + str(len(encounter_stack)))
+        if line_type == "mob_slain_other":
+            line_clean = re.sub(r"[^\w\s\,\-\'\`]", "", line)
+            target, source = line_clean.split(" has been slain by ")
+            mode = "slain"
+            result = "dead"
+        elif line_type == "mob_slain_you":
+            line_clean = re.sub(r"[^\w\s\,\-\'\`]", "", line)
+            source, target = line_clean.split(" have slain ")
+            source = state.char
+            mode = "slain"
+            result = "dead"
+        elif line_type == "you_new_zone":
+            pass
+        elif line_type == "faction_line":
+            pass
+
+        # Generate Encounter log
+        if len(encounter_stack) > 10:
+            target_count = {}
+            target_damage = {}
+
+            ## Determine Encounter Target
+            for event in encounter_stack:
+                time, source, target, mode, result = event
+                eqa_settings.log(
+                    time + " [" + source + " -> " + target + "] " + mode + " " + result
+                )
+
+                ### Build target count
+                if target not in target_count.keys():
+                    target_count[target] = 0
+                else:
+                    targetted = int(target_count.get(str(target)))
+                    targetted += 1
+                    target_count[target] = targetted
+
+            ## Read target count
+            high_count = 0
+            for target in target_count.keys():
+                if high_count < int(target_count.get(str(target))):
+                    high_count = int(target_count.get(str(target)))
+                    encounter_target = str(target)
+
+            ## Encounter Target
+            if state.debug == "true":
+                eqa_settings.log("Target: " + encounter_target)
+
+            ## Encounter Report
+            for event in encounter_stack:
+                time, source, target, mode, result = event
+                ### If event targets encounter target
+                if target == encounter_target:
+                    if source not in target_damage.keys():
+                        if mode == "damage" or mode == "spell":
+                            if not (
+                                result == "block"
+                                or result == "dodge"
+                                or result == "invulnerable"
+                                or result == "miss"
+                                or result == "parry"
+                                or result == "riposte"
+                                or result == "rune"
+                            ):
+                                target_damage[source] = int(result)
+                    else:
+                        if mode == "damage" or mode == "spell":
+                            if not (
+                                result == "block"
+                                or result == "dodge"
+                                or result == "invulnerable"
+                                or result == "miss"
+                                or result == "parry"
+                                or result == "riposte"
+                                or result == "rune"
+                            ):
+                                total_dmg = int(target_damage.get(source)) + int(result)
+                                target_damage[source] = total_dmg
+
+            eqa_settings.log("--- encounter summary ---")
+            for attacker in target_damage.keys():
+                eqa_settings.log(attacker + ": " + str(target_damage.get(attacker)))
+
+        encounter_stack.clear()
+
+    except Exception as e:
+        eqa_settings.log(
+            "encounter stop: Error on line "
+            + str(sys.exc_info()[-1].tb_lineno)
+            + ": "
+            + str(e)
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -1742,9 +1742,9 @@ def encounter_report(
                         ] = str(target_spell_damage_recieved[participant])
                         total_damage += int(target_spell_damage_recieved[participant])
                     if total_damage > 0 and int(encounter_duration) > 0:
-                        encounter_report["participants"][l_part]["dps_done"] = str(
-                            total_damage / int(encounter_duration)
-                        )
+                        encounter_report["participants"][l_part][
+                            "melee_dps_done"
+                        ] = str(total_damage / int(encounter_duration))
                     total_damage = 0
                     if participant in target_melee_damage_done.keys():
                         encounter_report["participants"][l_part][
@@ -1757,9 +1757,9 @@ def encounter_report(
                         ] = str(target_spell_damage_done[participant])
                         total_damage += int(target_spell_damage_done[participant])
                     if total_damage > 0 and int(encounter_duration) > 0:
-                        encounter_report["participants"][l_part]["dps_taken"] = str(
-                            total_damage / int(encounter_duration)
-                        )
+                        encounter_report["participants"][l_part][
+                            "melee_dps_taken"
+                        ] = str(total_damage / int(encounter_duration))
                     if participant in source_block.keys():
                         encounter_report["participants"][l_part][
                             "attacks_blocked"

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -1825,7 +1825,10 @@ def encounter_report(
                 encounter_report_file.close()
 
             ## Prune Old Events in encounter_stack
-            for event in encounter_stack:
+            count = 0
+            keep_encounter_stack = deque([])
+            while count < len(encounter_stack):
+                event = encounter_stack.popleft
                 time, source, target, mode, result = event
                 this_hour, this_minute, this_second_m = time.split(":")
                 this_second, this_milli = last_second_m.split(".")
@@ -1845,8 +1848,10 @@ def encounter_report(
                     message_age = int(first_half + second_half)
 
                 # If an event is more than 30 minutes old and still hasn't been used in an encounter log, remove it
-                if message_age > 18000:
-                    encounter_stack.remove(event)
+                if not message_age > 18000:
+                    keep_encounter_stack.append(event)
+
+            encounter_stack = keep_encounter_stack
 
     except Exception as e:
         eqa_settings.log(

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -1347,6 +1347,8 @@ def encounter_report(
                         int(first_minute),
                         int(first_second),
                     )
+                    this_encounter.append((time, source, target, mode, result))
+                    encounter_stack.remove(event)
                 ### Build list of events after first encounter, remove them from encounter_stack
                 elif (
                     found_time

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -1816,12 +1816,13 @@ def encounter_report(
             )
 
             ## Write Encounter to File
-            encounter_report_json_string = json.dumps(encounter_report, indent=2)
-            encounter_report_file = open(
-                encounter_zone_date_path + encounter_filename, "w"
-            )
-            encounter_report_file.write(encounter_report_json_string)
-            encounter_report_file.close()
+            if config["settings"]["encounter_parsing"]["auto_save"] == "true":
+                encounter_report_json_string = json.dumps(encounter_report, indent=2)
+                encounter_report_file = open(
+                    encounter_zone_date_path + encounter_filename, "w"
+                )
+                encounter_report_file.write(encounter_report_json_string)
+                encounter_report_file.close()
 
             ## Prune Old Events in encounter_stack
             for event in encounter_stack:

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -1349,9 +1349,7 @@ def encounter_report(
                     or found_time
                     and target == "Unknown"
                 ):
-                    this_encounter.append(
-                        (time, source, target, mode, result)
-                    )
+                    this_encounter.append((time, source, target, mode, result))
                     encounter_stack.remove(event)
 
             encounter_duration = int(
@@ -1365,6 +1363,7 @@ def encounter_report(
                 encounter_duration = int(first_half + last_half)
 
             ## Scrape This Encounter Events
+            pet_and_target_same = False
             this_encounter_events = len(this_encounter)
             target_melee_damage_recieved = {}
             target_melee_damage_done = {}
@@ -1401,6 +1400,8 @@ def encounter_report(
                 ### If mode is damage
                 if mode == "damage":
                     if target == encounter_target:
+                        if target == source:
+                            pet_and_target_same = True
                         if result == "block":
                             if target not in target_block.keys():
                                 target_block[target] = 1
@@ -1535,6 +1536,10 @@ def encounter_report(
                 this_encounter_events
             )
             encounter_report["encounter_summary"]["duration"] = str(encounter_duration)
+            if pet_and_target_same:
+                encounter_report["encounter_summary"][
+                    "warning"
+                ] = "This encounter likely includes one or more pets with the same name as the target.  All pet data in the encounter stack were attributed to the target."
 
             ### Encounter Target
             encounter_report["target"]["name"] = str(encounter_target)

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -1804,8 +1804,8 @@ def encounter_report(
                             encounter_heals.get(participant)
                         )
                     if participant in target_killed.keys():
-                        encounter_report["participants"][l_part]["killed"] = str(
-                            target_killed.keys
+                        encounter_report["participants"][l_part]["died"] = str(
+                            target_killed[participant]
                         )
 
             ## Send Report to Display

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -1458,18 +1458,6 @@ def encounter_report(
                                 target_melee_damage_recieved[source] = int(result)
                             else:
                                 target_melee_damage_recieved[source] += int(result)
-                            if source == encounter_target:
-                                if (
-                                    source
-                                    not in encounter_target_damage_done_total.keys()
-                                ):
-                                    encounter_target_damage_done_total[source] = int(
-                                        result
-                                    )
-                                else:
-                                    encounter_target_damage_done_total[source] += int(
-                                        result
-                                    )
                     elif source == encounter_target:
                         if result == "block":
                             if source not in source_block.keys():
@@ -1511,6 +1499,12 @@ def encounter_report(
                                 target_melee_damage_done[target] = int(result)
                             else:
                                 target_melee_damage_done[target] += int(result)
+                            if source not in encounter_target_damage_done_total.keys():
+                                encounter_target_damage_done_total[source] = int(result)
+                            else:
+                                encounter_target_damage_done_total[source] += int(
+                                    result
+                                )
                 ### If mode is spell
                 elif mode == "spell":
                     if result == "cast":

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -74,10 +74,21 @@ def process(
                         #### Disable active encounter
                         active_encounter = False
                         #### Generate combat report and reset encounter stack
+                        if line_type == "mob_slain_other":
+                            line_clean = re.sub(r"[^\w\s\,\-\'\`]", "", line)
+                            target, source = line_clean.split(" has been slain by ")
+                            if len(target.split()) > 1:
+                                encounter_report(
+                                    line_type, line_time, line, encounter_stack, state
+                                )
+                        else:
+                            encounter_report(
+                                line_type, line_time, line, encounter_stack, state
+                            )
+                    if line_type == "you_new_zone":
                         encounter_report(
                             line_type, line_time, line, encounter_stack, state
                         )
-                    if line_type == "you_new_zone":
                         encounter_stack.clear()
 
                 ## If we're in an encounter

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -1286,10 +1286,11 @@ def encounter_report(
             encounter_parse_date = datetime.now().strftime("%Y-%m-%d")
 
             encounter_path = config["settings"]["paths"]["encounter"]
+            clean_zone = re.sub(r"[^\w\s]", "", state.zone)
             if not os.path.exists(encounter_path):
                 os.makedirs(encounter_path)
             encounter_zone_path = (
-                encounter_path + state.zone.lower().replace(" ", "-") + "/"
+                encounter_path + clean_zone.lower().replace(" ", "-") + "/"
             )
             if not os.path.exists(encounter_zone_path):
                 os.makedirs(encounter_zone_path)
@@ -1380,7 +1381,7 @@ def encounter_report(
             encounter_target_damage_total = {}
             encounter_target_damage_done_total = {}
             encounter_target_spell_total = {}
-            encounter_target_spell_done_total
+            encounter_target_spell_done_total = {}
             target_block = {}
             target_dodge = {}
             target_invulnerable = {}

--- a/eqa/lib/encounter.py
+++ b/eqa/lib/encounter.py
@@ -58,6 +58,10 @@ def process(
                 interaction = new_message.tx
                 line = new_message.payload
 
+                ## Check for encounter_stack clear
+                if interaction == "clear":
+                    encounter_stack = []
+
                 ## If not an active encounter
                 if active_encounter == False:
                     ### And we see a line that indicates an encounter

--- a/eqa/lib/keys.py
+++ b/eqa/lib/keys.py
@@ -48,12 +48,8 @@ def process(
         while not exit_flag.is_set() and not cfg_reload.is_set():
 
             # Sleep between empty checks
-            queue_size = keyboard_q.qsize()
-            if queue_size < 10:
+            if keyboard_q.qsize() < 1:
                 time.sleep(0.01)
-            else:
-                time.sleep(0.001)
-                eqa_settings.log("keyboard_q depth: " + str(queue_size))
 
             # Check queue for message
             if not keyboard_q.empty():

--- a/eqa/lib/keys.py
+++ b/eqa/lib/keys.py
@@ -136,6 +136,16 @@ def process(
                                 "null",
                             )
                         )
+                    elif key == ord("e"):
+                        system_q.put(
+                            eqa_struct.message(
+                                eqa_settings.eqa_time(),
+                                "system",
+                                "encounter",
+                                "toggle",
+                                "null",
+                            )
+                        )
                     elif key == ord("m"):
                         system_q.put(
                             eqa_struct.message(

--- a/eqa/lib/keys.py
+++ b/eqa/lib/keys.py
@@ -41,6 +41,7 @@ def process(
 
     key = ""
     page = "events"
+    last_page = None
     settings = "character"
     selected_char = 0
 
@@ -86,17 +87,33 @@ def process(
                 elif key == ord("3"):
                     display_q.put(
                         eqa_struct.display(
+                            eqa_settings.eqa_time(), "draw", "parse", "null"
+                        )
+                    )
+                    page = "parse"
+                elif key == ord("4"):
+                    display_q.put(
+                        eqa_struct.display(
                             eqa_settings.eqa_time(), "draw", "settings", "null"
                         )
                     )
                     page = "settings"
-                elif key == ord("4"):
-                    display_q.put(
-                        eqa_struct.display(
-                            eqa_settings.eqa_time(), "draw", "help", "null"
+                elif key == ord("h"):
+                    if page == "help" and last_page is not None:
+                        display_q.put(
+                            eqa_struct.display(
+                                eqa_settings.eqa_time(), "draw", last_page, "null"
+                            )
                         )
-                    )
-                    page = "help"
+                        page = last_page
+                    else:
+                        last_page = page
+                        display_q.put(
+                            eqa_struct.display(
+                                eqa_settings.eqa_time(), "draw", "help", "null"
+                            )
+                        )
+                        page = "help"
                 elif key == ord("0"):
                     system_q.put(
                         eqa_struct.message(

--- a/eqa/lib/parser.py
+++ b/eqa/lib/parser.py
@@ -397,7 +397,8 @@ def check_spell(line):
         ):
             return "spell_no_target"
         elif (
-            re.fullmatch(r"^A missed note brings \w+'s song to a close\!$", line) is not None
+            re.fullmatch(r"^A missed note brings \w+'s song to a close\!$", line)
+            is not None
         ):
             return "song_interrupted_other"
 
@@ -692,7 +693,13 @@ def check_system_messages(line):
             return "command_error"
         elif re.fullmatch(r"^\w+ is not online at this time\.$", line) is not None:
             return "tell_offline"
-        elif re.fullmatch(r"^(Also, auto-follow works best in wide open areas with low lag\.  Twisty areas, lag, and other factors may cause auto-follow to fail\.|\*WARNING\*\: Do NOT use around lava, water, cliffs, or other dangerous areas because you WILL fall into them\. You have been warned\.)$", line) is not None:
+        elif (
+            re.fullmatch(
+                r"^(Also, auto-follow works best in wide open areas with low lag\.  Twisty areas, lag, and other factors may cause auto-follow to fail\.|\*WARNING\*\: Do NOT use around lava, water, cliffs, or other dangerous areas because you WILL fall into them\. You have been warned\.)$",
+                line,
+            )
+            is not None
+        ):
             return "autofollow_advice"
 
         return None
@@ -810,7 +817,12 @@ def check_loot_trade(line):
             is not None
         ):
             return "trade_item"
-        elif re.fullmatch(r"^You give \d+ (platinum|gold|silver|copper) to [a-zA-Z`\s]+\.$", line) is not None:
+        elif (
+            re.fullmatch(
+                r"^You give \d+ (platinum|gold|silver|copper) to [a-zA-Z`\s]+\.$", line
+            )
+            is not None
+        ):
             return "trade_npc_payment"
 
         return None

--- a/eqa/lib/parser.py
+++ b/eqa/lib/parser.py
@@ -38,10 +38,8 @@ def process(exit_flag, log_q, action_q):
 
             # Sleep between empty checks
             queue_size = log_q.qsize()
-            if queue_size < 4:
+            if queue_size < 1:
                 time.sleep(0.01)
-            else:
-                time.sleep(0.001)
 
             # Check queue for message
             if not log_q.empty():

--- a/eqa/lib/parser.py
+++ b/eqa/lib/parser.py
@@ -93,6 +93,16 @@ def determine(line):
         if line_type is not None:
             return line_type
 
+        # Spell Specific
+        line_type = check_spell_specific(line)
+        if line_type is not None:
+            return line_type
+
+        # Pets
+        line_type = check_pets(line)
+        if line_type is not None:
+            return line_type
+
         # Received Player Chat
         line_type = check_received_chat(line)
         if line_type is not None:
@@ -100,11 +110,6 @@ def determine(line):
 
         # Sent Player Chat
         line_type = check_sent_chat(line)
-        if line_type is not None:
-            return line_type
-
-        # Spell Specific
-        line_type = check_spell_specific(line)
         if line_type is not None:
             return line_type
 
@@ -135,11 +140,6 @@ def determine(line):
 
         # Who
         line_type = check_who(line)
-        if line_type is not None:
-            return line_type
-
-        # Pets
-        line_type = check_pets(line)
         if line_type is not None:
             return line_type
 
@@ -187,6 +187,14 @@ def check_melee(line):
             is not None
         ):
             return "combat_other_melee_dodge"
+        elif (
+            re.fullmatch(
+                r"^[a-zA-Z`\s]+ tries to (maul|hit|crush|slash|pierce|bash|backstab|bite|kick|claw|gore|punch|strike|slice) [a-zA-Z\s]+, but [a-zA-Z`\s]+ is INVULNERABLE\!$",
+                line,
+            )
+            is not None
+        ):
+            return "combat_other_melee_invulnerable"
         elif (
             re.fullmatch(
                 r"^[a-zA-Z`\s]+ tries to (maul|hit|crush|slash|pierce|bash|backstab|bite|kick|claw|gore|punch|strike|slice) [a-zA-Z`\s]+, but [a-zA-Z`\s]+ parries\!$",
@@ -293,10 +301,6 @@ def check_melee(line):
             return "experience_group"
         elif re.fullmatch(r"^You have lost experience\.$", line) is not None:
             return "experience_lost"
-        elif re.fullmatch(r"^You are stunned\!$", line) is not None:
-            return "combat_you_stun_on"
-        elif re.fullmatch(r"^You are unstunned\.$", line) is not None:
-            return "combat_you_stun_off"
 
         return None
 
@@ -383,6 +387,14 @@ def check_spell(line):
             return "spell_forget"
         elif re.fullmatch(r"^Your [a-zA-Z\s]+ spell has worn off\.$", line) is not None:
             return "spell_worn_off"
+        elif (
+            re.fullmatch(
+                r"^You try to cast a spell on [a-zA-Z`\s]+, but they are protected\.$",
+                line,
+            )
+            is not None
+        ):
+            return "spell_protected"
         elif re.fullmatch(r"^You haven't recovered yet\.\.\.$", line) is not None:
             return "spell_cooldown_active"
         elif (
@@ -562,7 +574,17 @@ def check_command_output(line):
             re.fullmatch(r"^You can\'t use that command while casting\.\.\.$", line)
             is not None
         ):
+            return "command_block_casting"
+        elif (
+            re.fullmatch(r"^You can\'t use that command right now\.\.\.$", line)
+            is not None
+        ):
             return "command_block"
+        elif (
+            re.fullmatch(r"^That is not a valid command\.  Please use \/help\.$", line)
+            is not None
+        ):
+            return "command_invalid"
 
         return None
 
@@ -691,6 +713,16 @@ def check_system_messages(line):
             return "command_error"
         elif re.fullmatch(r"^\w+ is not online at this time\.$", line) is not None:
             return "tell_offline"
+        elif re.fullmatch(r"^Consider whom\?$", line) is not None:
+            return "consider_no_target"
+        elif re.fullmatch(r"^Auto attack off\.$", line) is not None:
+            return "you_auto_attack_off"
+        elif re.fullmatch(r"^Auto attack on\.$", line) is not None:
+            return "you_auto_attack_on"
+        elif re.fullmatch(r"^You are stunned\!$", line) is not None:
+            return "you_stun_on"
+        elif re.fullmatch(r"^You are unstunned\.$", line) is not None:
+            return "you_stun_off"
         elif (
             re.fullmatch(
                 r"^(Also, auto-follow works best in wide open areas with low lag\.  Twisty areas, lag, and other factors may cause auto-follow to fail\.|\*WARNING\*\: Do NOT use around lava, water, cliffs, or other dangerous areas because you WILL fall into them\. You have been warned\.)$",
@@ -953,7 +985,7 @@ def check_who(line):
             return "who_line_friends"
         elif (
             re.fullmatch(
-                r"^( AFK |\<LINKDEAD\>| AFK  <LINKDEAD>|)\[(\d+ [a-zA-Z\s]+|ANONYMOUS)\] \w+( \([a-zA-Z\s]+\)|)( \<[a-zA-Z\s]+\>|  \<[a-zA-Z\s]+\>|)( ZONE\: \w+|  ZONE\: \w+|)( LFG|)$",
+                r"^( AFK |\<LINKDEAD\>| AFK  <LINKDEAD>|)\[(\d+ [a-zA-Z\s]+|ANONYMOUS)\] \w+( \([a-zA-Z\s]+\)|)( \<[a-zA-Z\s]+\>|  \<[a-zA-Z\s]+\>|)( ZONE\: \w+|  ZONE\: \w+|)( LFG|  LFG|)$",
                 line,
             )
             is not None

--- a/eqa/lib/parser.py
+++ b/eqa/lib/parser.py
@@ -719,6 +719,8 @@ def check_system_messages(line):
             return "you_auto_attack_off"
         elif re.fullmatch(r"^Auto attack on\.$", line) is not None:
             return "you_auto_attack_on"
+        elif re.fullmatch(r"^You lack the proper key\.$", line) is not None:
+            return "wrong_key"
         elif re.fullmatch(r"^You are stunned\!$", line) is not None:
             return "you_stun_on"
         elif re.fullmatch(r"^You are unstunned\.$", line) is not None:

--- a/eqa/lib/sound.py
+++ b/eqa/lib/sound.py
@@ -46,12 +46,8 @@ def process(config, sound_q, exit_flag, cfg_reload):
         while not exit_flag.is_set() and not cfg_reload.is_set():
 
             # Sleep between empty checks
-            queue_size = sound_q.qsize()
-            if queue_size < 2:
+            if sound_q.qsize() < 1:
                 time.sleep(0.01)
-            else:
-                time.sleep(0.001)
-                eqa_settings.log("sound_q depth: " + str(queue_size))
 
             # Check queue for message
             if not sound_q.empty():

--- a/eqa/lib/sound.py
+++ b/eqa/lib/sound.py
@@ -29,7 +29,7 @@ import eqa.lib.struct as eqa_struct
 import eqa.lib.settings as eqa_settings
 
 
-def process(config, sound_q, exit_flag, cfg_reload):
+def process(config, sound_q, exit_flag, cfg_reload, state):
     """
     Process: sound_q
     Produce: sound event
@@ -58,9 +58,17 @@ def process(config, sound_q, exit_flag, cfg_reload):
                     mute_speak = sound_event.payload
                 elif sound_event.sound == "mute_alert":
                     mute_alert = sound_event.payload
-                elif sound_event.sound == "speak" and not mute_speak == "true":
+                elif (
+                    sound_event.sound == "speak"
+                    and not mute_speak == "true"
+                    and not state.mute == "true"
+                ):
                     speak(sound_event.payload, "true", tmp_sound_file_path)
-                elif sound_event.sound == "alert" and not mute_alert == "true":
+                elif (
+                    sound_event.sound == "alert"
+                    and not mute_alert == "true"
+                    and not state.mute == "true"
+                ):
                     alert(config, sound_event.payload)
 
                 sound_q.task_done()

--- a/eqa/lib/state.py
+++ b/eqa/lib/state.py
@@ -43,6 +43,7 @@ class EQA_State:
         char_level,
         char_class,
         char_guild,
+        encounter_parse,
     ):
         """All States"""
         self.char = char
@@ -62,6 +63,7 @@ class EQA_State:
         self.char_level = char_level
         self.char_class = char_class
         self.char_guild = char_guild
+        self.encounter_parse = encounter_parse
 
     def set_char(self, char):
         """Set Character"""
@@ -130,3 +132,7 @@ class EQA_State:
     def set_guild(self, char_guild):
         """Set Guild"""
         self.char_guild = char_guild
+
+    def set_encounter_parse(self, encounter_parse):
+        """Set Encounter Parse"""
+        self.encounter_parse = encounter_parse

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="eqalert",
-    version="2.11.0",
+    version="2.11.1",
     author="Michael Geitz",
     author_email="git@geitz.xyz",
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="eqalert",
-    version="2.10.3",
+    version="2.11.0",
     author="Michael Geitz",
     author_email="git@geitz.xyz",
     install_requires=[


### PR DESCRIPTION
![druid](https://user-images.githubusercontent.com/1339169/165641278-a7dfd230-68d7-4175-8e5f-14d9dbfbad33.gif)

# Encounter Parsing & Reporting

Enabled by default on first start-up.  Toggled using the controls below.

Auto-save of encounter parse to `json` is disabled by default in `settings > encounter_parsing > auto_save`, change this value to `true` to have each encounter saved to a file.

Controls:
```
'e' - press the e key on any tab to toggle encounter parsing
/say parser encounter - toggle encounter parsing
/say parser encounter clear - clear encounter stack
/say parser encounter end - end current encounter
```

When encounter parsing is enabled,

If an encounter is detected; store that encounter event and listen for more

if the end of an encounter is detected; if we know who the target was we can make a report, otherwise we can figure out who the encounter target was and still make a report - assuming there are enough events to make a reasonable report from.

Generate the report using only events relevant to the target identified, and include each event participant.  Remove any events used to generate the report from what remains in the encounter_stack.

Send the report to a file in `~/.eqa/encounters/[zone]/[date]/time_mob.json` 

Send it to the display to show either a shortened version on the events tab, or more details on the parser tab.

> When zoning, the parser will try to make an encounter report (more than 20 remaining encounter stack events) and then clear the encounter stack

> If encounter events are left in the stack for more than 30 minutes (you run past some random combat in zone), they will be removed

In general, encounter parsing here is mostly only as good the logs are.  The logging radius on the green server is smaller than on blue, and certain log lines containing very useful and specific information are only shown to the source or target - a great example here is healing (or the non-existant DoT damage log lines).

~~One caveat with how this fits into the larger parser implementation; the recent change to scale up process_action to 4 threads means there is a race condition with the very final event(s) of the encounter and the event indicating the encounter is over.  This can be reproduced by starting an encounter with a very low level mob, building up enough (at least 20) encounter events and then finishing the mob with a spell: <100% of the time the final spell damage will show in the encounter log.  This means that final event is still in the encounter stack and will cause an issue with the duration of the next encounter to happen with any mob with that name (before manually clearing the stack or zoning).~~ fixed

~~So, this may mean process_action will be dialed down to preserve accuracy.~~ it was, seems still just as fast

#### Future Improvements

There are 3 goals for this feature:

1. Always identify when an encounter starts
2. Always identify when an encounter ends
3. Capture and report on every relevant encounter log entry

One critical component to number 3 is the log message must be a log message anyone can recieve.  Relying too much on the logs only shown for the player isn't fun, but I think capturing heals is an exception here.

# Action Cleanup

- Control flow more clear
- Lots of general clean-up

# Faster Performance

- I think I figured out the thread-queue-sleep-with-exit-flag-without-setting-a-performance-limit problem

# Resolves (after much time)

Resolves #22 
Resolves #23 
