### PR TITLE
An Undetermined Sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,13 @@ This file will regenerate with each new `eqalert` version or when `data/spell-ti
 
 You can control some parser settings using `/say` in-game.  This is better suited for one monitor setups.
 
+#### Settings
+
 `/say parser raid` - Toggle raid mode
 
 `/say parser debug` - Toggle debug mode
+
+#### Mute
 
 `/say parser mute/unmute` - Toggle global mute/unmute
 
@@ -126,11 +130,15 @@ You can control some parser settings using `/say` in-game.  This is better suite
 
 > Does not effect global mute
 
+#### Encounters
+
 `/say parser encounter` - Toggle encounter parsing
 
 `/say parser encounter clear` - Clear the encounter stack
 
 `/say parser encounter end` - Sometimes, your logs don't catch an encounter end.  Use this command to fix that!
+
+#### Timers
 
 `/say parser metronome [seconds]` - Set a tick/tock metronome with n interval of [seconds]
 
@@ -143,6 +151,8 @@ You can control some parser settings using `/say` in-game.  This is better suite
 `/say parser timer respawn` - Create timers for the default current zone time after seeing an experience message. Timer response is "pop zone"
 
 `/say parser timer respawn stop` - Stop creating timers automatically
+
+#### Misc
 
 `/say parser what context` - Speak context state
 

--- a/README.md
+++ b/README.md
@@ -144,13 +144,15 @@ You can control some parser settings using `/say` in-game.  This is better suite
 
 `/say parser timer respawn stop` - Stop creating timers automatically
 
-`/say parser hello`
+`/say parser what context` - Speak context state
 
-`/say parser who`
+`/say parser what state` - Speak *everything* in the state object
 
-`/say parser where`
+`/say parser hello` - Hello
 
-`/say parser what state`
+`/say parser who` - Who am I?
+
+`/say parser where` - Where am I?
 
 
 ## Custom Alerting

--- a/eqa/eqalert.py
+++ b/eqa/eqalert.py
@@ -398,6 +398,9 @@ def main():
                     ### Update raid status
                     elif new_message.tx == "raid":
                         system_raid(configs, state, display_q, sound_q, new_message)
+                    ### Update consider eval status
+                    elif new_message.tx == "consider":
+                        system_consider(configs, state, display_q, sound_q, new_message)
                     ### Update debug status
                     elif new_message.tx == "debug":
                         system_debug(configs, state, display_q, sound_q, new_message)
@@ -522,6 +525,7 @@ def main():
                             state.set_encounter_parse_save(new_state.save_parse)
                             state.set_auto_raid(new_state.auto_raid)
                             state.set_auto_mob_timer(new_state.auto_mob_timer)
+                            state.set_consider_eval(new_state.consider_eval)
                             eqa_config.set_last_state(state, configs)
                             char_log = new_char_log
                             # Start new log watch
@@ -594,6 +598,7 @@ def main():
                         state.set_encounter_parse_save(new_state.save_parse)
                         state.set_auto_raid(new_state.auto_raid)
                         state.set_auto_mob_timer(new_state.auto_mob_timer)
+                        state.set_consider_eval(new_state.consider_eval)
                         #### Stop state dependent processes
                         cfg_reload.set()
                         process_action.join()
@@ -943,6 +948,49 @@ def system_timer(configs, state, display_q, sound_q, new_message):
     except Exception as e:
         eqa_settings.log(
             "system debug: Error on line "
+            + str(sys.exc_info()[-1].tb_lineno)
+            + ": "
+            + str(e)
+        )
+
+
+def system_consider(configs, state, display_q, sound_q, new_message):
+    """Perform system tasks for consider eval behavior"""
+
+    try:
+        # Toggle consider eval state to true
+        if state.consider_eval == "false" and new_message.payload == "true":
+            state.set_consider_eval("true")
+            eqa_config.set_last_state(state, configs)
+            display_q.put(
+                eqa_struct.display(
+                    eqa_settings.eqa_time(),
+                    "event",
+                    "events",
+                    "Consider evaluation enabled",
+                )
+            )
+            sound_q.put(eqa_struct.sound("speak", "Consider evaluation enabled"))
+        # Toggle consider eval state to false
+        elif state.consider_eval == "true" and new_message.payload == "false":
+            state.set_consider_eval("false")
+            eqa_config.set_last_state(state, configs)
+            display_q.put(
+                eqa_struct.display(
+                    eqa_settings.eqa_time(),
+                    "event",
+                    "events",
+                    "Consider evaluation disabled",
+                )
+            )
+            sound_q.put(eqa_struct.sound("speak", "Consider evaluation disabled"))
+        display_q.put(
+            eqa_struct.display(eqa_settings.eqa_time(), "draw", "redraw", "null")
+        )
+
+    except Exception as e:
+        eqa_settings.log(
+            "system consider: Error on line "
             + str(sys.exc_info()[-1].tb_lineno)
             + ": "
             + str(e)

--- a/eqa/lib/action.py
+++ b/eqa/lib/action.py
@@ -195,6 +195,10 @@ def process(
                                 "Pop " + str(state.zone),
                             )
                         )
+                ## Consider Evaluation
+                if state.consider_eval == "true":
+                    if line_type == "consider":
+                        action_consider_evaluation(sound_q, check_line)
 
                 ## State Building Line Types
                 if line_type == "location":
@@ -777,6 +781,38 @@ def reaction_alert(
     except Exception as e:
         eqa_settings.log(
             "reaction alert: Error on line "
+            + str(sys.exc_info()[-1].tb_lineno)
+            + ": "
+            + str(e)
+        )
+
+
+def action_consider_evaluation(sound_q, check_line):
+    """Evaluate consider lines"""
+
+    try:
+        faction, level = check_line.split(" -- ")
+        if "threateningly" in faction or "scowls" in faction:
+            if (
+                "gamble" in level
+                or "floor" in level
+                or "tombstone" in level
+                or "formidable" in level
+            ):
+                danger = True
+            else:
+                danger = False
+        else:
+            danger = False
+
+        if danger:
+            sound_q.put(eqa_struct.sound("speak", "danger"))
+        else:
+            sound_q.put(eqa_struct.sound("speak", "safe"))
+
+    except Exception as e:
+        eqa_settings.log(
+            "action consider evaluate: Error on line "
             + str(sys.exc_info()[-1].tb_lineno)
             + ": "
             + str(e)

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -11846,6 +11846,11 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "rewind_output_wait": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "target_attack_too_far": {
       "alert": {},
       "reaction": "solo",
@@ -11920,6 +11925,11 @@ def build_config(base_path):
       "alert": {},
       "reaction": "all",
       "sound": "wrong key or place"
+    },
+    "yell_help": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "help"
     },
     "you_auto_attack_off": {
       "alert": {},

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -11408,6 +11408,16 @@ def build_config(base_path):
       "alert": {},
       "reaction": "false",
       "sound": "false"
+    },
+    "tell_npc_bank_closed": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "tell_npc_bank_open": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
     }
   },
   "version": "%s"
@@ -11502,6 +11512,11 @@ def build_config(base_path):
       "alert": {},
       "reaction": "solo",
       "sound": "true"
+    },
+    "tell_unknown_tongue": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
     }
   },
   "version": "%s"
@@ -11614,12 +11629,32 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "forage_edible": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "forage_not_edible": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "forage_standing": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
     },
     "hide_corpse_all": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "inspect_toggle_off": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "inspect_toggle_on": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -11777,6 +11812,21 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "corpse_decay_timer": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "corpse_res_timer": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "corpse_too_old": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "ding_down": {
       "alert": {},
       "reaction": "all",
@@ -11842,10 +11892,20 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "inspect_other": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "inspect_you": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
+    },
+    "item_dropped": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "item dropped"
     },
     "motd_welcome": {
       "alert": {},
@@ -11881,6 +11941,11 @@ def build_config(base_path):
       "alert": {},
       "reaction": "false",
       "sound": "false"
+    },
+    "tell_yourself": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "true"
     },
     "titanium_client_help_message": {
       "alert": {},
@@ -12184,6 +12249,16 @@ def build_config(base_path):
       "sound": "false"
     },
     "trade_money_add": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "trade_npc_item_price": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "trade_npc_item_sold": {
       "alert": {},
       "reaction": "false",
       "sound": "false"

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -2716,6 +2716,11 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "combat_you_cannot_see": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "can't see"
+    },
     "combat_you_ds_fire_damage": {
       "alert": {},
       "reaction": "false",
@@ -11881,6 +11886,11 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "tracking_begin": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "tracking_target_lost": {
       "alert": {},
       "reaction": "false",
@@ -12059,6 +12069,11 @@ def build_config(base_path):
       "reaction": "solo",
       "sound": "true"
     },
+    "group_invite_you_cancel": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "group_join_notify": {
       "alert": {},
       "reaction": "false",
@@ -12137,10 +12152,15 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
-    "looted_wait": {
+    "loot_wait": {
       "alert": {},
       "reaction": "solo",
       "sound": "no yet"
+    },
+    "loot_too_far": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "too far"
     },
     "trade_cancel_you": {
       "alert": {},

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -2839,7 +2839,12 @@ def build_config(base_path):
       "reaction": "solo",
       "sound": "cured"
     },
-    "spells_damage": {
+    "spells_damage_other": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "spells_damage_you": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -2910,6 +2915,21 @@ def build_config(base_path):
       "sound": "false"
     },
     "spells_memorize_finish": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "spells_scribe_begin": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "spells_scribe_swap": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "spells_scribe_swap_instruction": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -11508,6 +11528,11 @@ def build_config(base_path):
     new_line_command_output_config = """
 {
   "line": {
+    "client_ui_load": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "command_block": {
       "alert": {},
       "reaction": "false",
@@ -11547,6 +11572,16 @@ def build_config(base_path):
       "alert": {},
       "reaction": "solo",
       "sound": "It's OK! I'll be your friend!"
+    },
+    "forage_cursor_empty": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "forage_standing": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
     },
     "location": {
       "alert": {},
@@ -11720,6 +11755,11 @@ def build_config(base_path):
       "alert": {},
       "reaction": "false",
       "sound": "false"
+    },
+    "target_attack_too_far": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "too far"
     },
     "tell_offline": {
       "alert": {},
@@ -12085,6 +12125,11 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "emote_bye_other": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "emote_bye_you": {
       "alert": {},
       "reaction": "false",
@@ -12446,6 +12491,11 @@ def build_config(base_path):
       "sound": "false"
     },
     "emote_thirsty_you": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "emote_veto_other": {
       "alert": {},
       "reaction": "false",
       "sound": "false"

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -11767,6 +11767,11 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "consider": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "consider_no_target": {
       "alert": {},
       "reaction": "false",

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -3302,6 +3302,21 @@ def build_config(base_path):
       "reaction": "raid",
       "sound": "avatar power"
     },
+    "spell_avatar_snare_other_on": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "spell_avatar_snare_you_on": {
+      "alert": {},
+      "reaction": "raid",
+      "sound": "avatar snare"
+    },
+    "spell_avatar_snare_you_off": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "spell_avatar_you_off": {
       "alert": {},
       "reaction": "false",
@@ -4158,6 +4173,11 @@ def build_config(base_path):
       "sound": "false"
     },
     "spell_circle_of_summer_you_on": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "spell_circle_of_the_combines_other_on": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -10972,6 +10992,11 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "spell_upheaval_other_on": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "spell_upheaval_you_on": {
       "alert": {},
       "reaction": "false",
@@ -11363,6 +11388,11 @@ def build_config(base_path):
       "reaction": "alert",
       "sound": "look at auction"
     },
+    "broadcast": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "true"
+    },
     "group": {
       "alert": {
         "drop": "raid",
@@ -11513,6 +11543,11 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "empty_friends": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "It's OK! I'll be your friend!"
+    },
     "location": {
       "alert": {},
       "reaction": "false",
@@ -11631,6 +11666,11 @@ def build_config(base_path):
       "reaction": "all",
       "sound": "congratulations"
     },
+    "drag_permission_received": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "true"
+    },
     "earthquake": {
       "alert": {},
       "reaction": "solo",
@@ -11686,6 +11726,11 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "titanium_client_help_message": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "tracking": {
       "alert": {},
       "reaction": "false",
@@ -11702,6 +11747,21 @@ def build_config(base_path):
       "sound": "false"
     },
     "weather_start_rain": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "walk_of_shame": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "warrior_berserk_on": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "warrior_berserk_off": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -12145,6 +12205,11 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "emote_grin_other": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "emote_grin_you": {
       "alert": {},
       "reaction": "false",
@@ -12161,6 +12226,11 @@ def build_config(base_path):
       "sound": "false"
     },
     "emote_happy_you": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "emote_hug_other": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -12251,6 +12321,11 @@ def build_config(base_path):
       "sound": "false"
     },
     "emote_point_you": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "emote_poke_other": {
       "alert": {},
       "reaction": "false",
       "sound": "false"

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -1978,6 +1978,9 @@ def set_last_state(state, configs):
                 "auto_mob_timer": str(state.auto_mob_timer),
             }
         )
+        configs.settings.config["settings"]["consider_eval"].update(
+            {"enabled": str(state.consider_eval)}
+        )
         configs.settings.config["settings"]["debug_mode"].update(
             {"enabled": str(state.debug)}
         )
@@ -2089,6 +2092,7 @@ def get_last_state(configs, char_name, char_server):
         encounter_parse = configs.settings.config["settings"]["encounter_parsing"][
             "enabled"
         ]
+        consider_eval = configs.settings.config["settings"]["consider_eval"]["enabled"]
         debug = configs.settings.config["settings"]["debug_mode"]["enabled"]
         mute = configs.settings.config["settings"]["mute"]["enabled"]
         save_parse = configs.settings.config["settings"]["encounter_parsing"][
@@ -2124,6 +2128,7 @@ def get_last_state(configs, char_name, char_server):
             save_parse,
             auto_raid,
             auto_mob_timer,
+            consider_eval,
         )
 
         return state
@@ -2198,6 +2203,9 @@ def build_config(base_path):
 {
   "last_state": {},
   "settings": {
+    "consider_eval": {
+      "enabled": "true"
+    },
     "debug_mode": {
       "enabled": "false"
     },

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -425,6 +425,7 @@ def update_spell_timers(data_path, eq_spells_file_path):
             "avalanche",
             "avatar",
             "avatar_power",
+            "avatar_snare",
             "bandoleer_of_luclin",
             "bane_of_nife",
             "banish_summoned",
@@ -2651,6 +2652,16 @@ def build_config(base_path):
       "reaction": "solo",
       "sound": "no target"
     },
+    "combat_other_ds_fire_damage": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "combat_other_ds_thorns_damage": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "combat_other_melee": {
       "alert": {},
       "reaction": "false",
@@ -2702,16 +2713,6 @@ def build_config(base_path):
       "sound": "false"
     },
     "combat_other_rune_damage": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
-    },
-    "combat_other_ds_fire_damage": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
-    },
-    "combat_other_ds_thorns_damage": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -2800,16 +2801,16 @@ def build_config(base_path):
       "alert": {},
       "reaction": "solo_group_only",
       "sound": "true"
-    }
-    "you_slain": {
-      "alert": {},
-      "reaction": "solo_only",
-      "sound": "true"
-    }
+    },
     "unconscious": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
+    },
+    "you_slain": {
+      "alert": {},
+      "reaction": "solo_only",
+      "sound": "true"
     }
   },
   "version": "%s"
@@ -2939,26 +2940,6 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
-    "spells_scribe_begin": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
-    },
-    "spells_scribe_finish": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
-    },
-    "spells_scribe_swap": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
-    },
-    "spells_scribe_swap_instruction": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
-    },
     "spells_no_target": {
       "alert": {},
       "reaction": "false",
@@ -2995,6 +2976,26 @@ def build_config(base_path):
       "sound": "resist"
     },
     "spells_resist_you": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "spells_scribe_begin": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "spells_scribe_finish": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "spells_scribe_swap": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "spells_scribe_swap_instruction": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -3352,15 +3353,15 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
-    "spell_avatar_snare_you_on": {
-      "alert": {},
-      "reaction": "raid",
-      "sound": "avatar snare"
-    },
     "spell_avatar_snare_you_off": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
+    },
+    "spell_avatar_snare_you_on": {
+      "alert": {},
+      "reaction": "raid",
+      "sound": "avatar snare"
     },
     "spell_avatar_you_off": {
       "alert": {},
@@ -10732,6 +10733,11 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "spell_talisman_of_the_serpent_you_on": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "spell_taper_enchantment_other_on": {
       "alert": {},
       "reaction": "false",
@@ -11326,11 +11332,6 @@ def build_config(base_path):
       "alert": {},
       "reaction": "false",
       "sound": "false"
-    },
-    "spell_talisman_of_the_serpent_you_on": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
     }
   },
   "version": "%s"
@@ -11628,12 +11629,12 @@ def build_config(base_path):
       "reaction": "solo",
       "sound": "good luck"
     },
-    "list_none": {
+    "list_leaving": {
       "alert": {},
-      "reaction": "false",
-      "sound": "false"
+      "reaction": "solo",
+      "sound": "leaving list area"
     },
-    "list_position": {
+    "list_none": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -11643,10 +11644,10 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
-    "list_leaving": {
+    "list_position": {
       "alert": {},
-      "reaction": "solo",
-      "sound": "leaving list area"
+      "reaction": "false",
+      "sound": "false"
     },
     "location": {
       "alert": {},
@@ -11688,15 +11689,15 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
-    "summon_corpse_none": {
-      "alert": {},
-      "reaction": "solo",
-      "sound": "well thats a good thing, right?"
-    },
     "summon_corpse_no_consent": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
+    },
+    "summon_corpse_none": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "well thats a good thing, right?"
     },
     "target": {
       "alert": {},
@@ -11751,15 +11752,15 @@ def build_config(base_path):
     new_line_system_messages_config = """
 {
   "line": {
-    "autofollow_advice": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
-    },
     "auto_inventory_full": {
       "alert": {},
       "reaction": "solo",
       "sound": "inventory full"
+    },
+    "autofollow_advice": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
     },
     "command_error": {
       "alert": {},
@@ -11821,17 +11822,17 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "hide_disabled": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "hide_drop": {
       "alert": {},
       "reaction": "solo",
       "sound": "hide drop"
     },
     "hide_enabled": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
-    },
-    "hide_disabled": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -11866,17 +11867,17 @@ def build_config(base_path):
       "reaction": "solo",
       "sound": "can't see"
     },
+    "target_lost": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "tell_offline": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
     },
     "titanium_client_help_message": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
-    },
-    "target_lost": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -11891,11 +11892,6 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
-    "tracking_target_lost": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
-    },
     "tracking_player_off": {
       "alert": {},
       "reaction": "false",
@@ -11906,7 +11902,7 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
-    "weather_start_rain": {
+    "tracking_target_lost": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -11916,12 +11912,17 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "warrior_berserk_off": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "warrior_berserk_on": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
     },
-    "warrior_berserk_off": {
+    "weather_start_rain": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -12039,15 +12040,15 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
-    "group_created": {
-      "alert": {},
-      "reaction": "false",
-      "sound": "false"
-    },
     "group_considering": {
       "alert": {},
       "reaction": "solo",
       "sound": "considering"
+    },
+    "group_created": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
     },
     "group_disbanded": {
       "alert": {},
@@ -12132,6 +12133,16 @@ def build_config(base_path):
     new_line_loot_trade_config = """
 {
   "line": {
+    "loot_too_far": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "too far"
+    },
+    "loot_wait": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "no yet"
+    },
     "looted_item_other": {
       "alert": {},
       "reaction": "false",
@@ -12151,16 +12162,6 @@ def build_config(base_path):
       "alert": {},
       "reaction": "false",
       "sound": "false"
-    },
-    "loot_wait": {
-      "alert": {},
-      "reaction": "solo",
-      "sound": "no yet"
-    },
-    "loot_too_far": {
-      "alert": {},
-      "reaction": "solo",
-      "sound": "too far"
     },
     "trade_cancel_you": {
       "alert": {},
@@ -12495,12 +12496,12 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
-    "emote_nod_you": {
+    "emote_nod_other": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
     },
-    "emote_nod_other": {
+    "emote_nod_you": {
       "alert": {},
       "reaction": "false",
       "sound": "false"

--- a/eqa/lib/config.py
+++ b/eqa/lib/config.py
@@ -2646,6 +2646,11 @@ def build_config(base_path):
     new_line_combat_config = """
 {
   "line": {
+    "combat_no_target": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "no target"
+    },
     "combat_other_melee": {
       "alert": {},
       "reaction": "false",
@@ -2791,6 +2796,16 @@ def build_config(base_path):
       "reaction": "solo_group_only",
       "sound": "true"
     }
+    "you_slain": {
+      "alert": {},
+      "reaction": "solo_only",
+      "sound": "true"
+    }
+    "unconscious": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    }
   },
   "version": "%s"
 }
@@ -2920,6 +2935,11 @@ def build_config(base_path):
       "sound": "false"
     },
     "spells_scribe_begin": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "spells_scribe_finish": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -11563,6 +11583,16 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "drink_you": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "drink_you_finish": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "eat_other": {
       "alert": {},
       "reaction": "false",
@@ -11582,6 +11612,36 @@ def build_config(base_path):
       "alert": {},
       "reaction": "false",
       "sound": "false"
+    },
+    "hide_corpse_all": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "list_added": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "good luck"
+    },
+    "list_none": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "list_position": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "list_out_of_range": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "list_leaving": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "leaving list area"
     },
     "location": {
       "alert": {},
@@ -11619,6 +11679,16 @@ def build_config(base_path):
       "sound": "false"
     },
     "summon_corpse": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "summon_corpse_none": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "well thats a good thing, right?"
+    },
+    "summon_corpse_no_consent": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -11680,6 +11750,11 @@ def build_config(base_path):
       "alert": {},
       "reaction": "false",
       "sound": "false"
+    },
+    "auto_inventory_full": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "inventory full"
     },
     "command_error": {
       "alert": {},
@@ -11751,7 +11826,22 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "hide_disabled": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "inspect_you": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "motd_welcome": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "rewind_output": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -11760,6 +11850,11 @@ def build_config(base_path):
       "alert": {},
       "reaction": "solo",
       "sound": "too far"
+    },
+    "target_cannot_see": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "can't see"
     },
     "tell_offline": {
       "alert": {},
@@ -11771,7 +11866,17 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "target_lost": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "tracking": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "tracking_target_lost": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -11909,6 +12014,11 @@ def build_config(base_path):
       "reaction": "solo",
       "sound": "is anyone there?"
     },
+    "group_already": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "group_created": {
       "alert": {},
       "reaction": "false",
@@ -11978,6 +12088,16 @@ def build_config(base_path):
       "alert": {},
       "reaction": "solo",
       "sound": "true"
+    },
+    "guild_new_member": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "welcome"
+    },
+    "invite_no_target": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
     }
   },
   "version": "%s"
@@ -12006,6 +12126,11 @@ def build_config(base_path):
       "alert": {},
       "reaction": "false",
       "sound": "false"
+    },
+    "looted_wait": {
+      "alert": {},
+      "reaction": "solo",
+      "sound": "no yet"
     },
     "trade_cancel_you": {
       "alert": {},
@@ -12310,6 +12435,11 @@ def build_config(base_path):
       "reaction": "false",
       "sound": "false"
     },
+    "emote_laugh_other": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
     "emote_laugh_you": {
       "alert": {},
       "reaction": "false",
@@ -12336,6 +12466,11 @@ def build_config(base_path):
       "sound": "false"
     },
     "emote_nod_you": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "emote_nod_other": {
       "alert": {},
       "reaction": "false",
       "sound": "false"
@@ -12411,6 +12546,11 @@ def build_config(base_path):
       "sound": "false"
     },
     "emote_rofl_you": {
+      "alert": {},
+      "reaction": "false",
+      "sound": "false"
+    },
+    "emote_salute_other": {
       "alert": {},
       "reaction": "false",
       "sound": "false"

--- a/eqa/lib/curses.py
+++ b/eqa/lib/curses.py
@@ -1212,11 +1212,10 @@ def draw_state(stdscr, state):
         stdscr.addstr(25, 16, ": ", curses.color_pair(1))
         stdscr.addstr(25, 18, state.encounter_parse.title(), curses.color_pair(3))
 
-        # eqalert version
-        version = str(pkg_resources.get_distribution("eqalert").version)
-        stdscr.addstr(28, 5, "Version", curses.color_pair(2))
-        stdscr.addstr(28, 16, ": ", curses.color_pair(1))
-        stdscr.addstr(28, 18, version, curses.color_pair(3))
+        # consider evaluation state
+        stdscr.addstr(26, 5, "Consider", curses.color_pair(2))
+        stdscr.addstr(26, 16, ": ", curses.color_pair(1))
+        stdscr.addstr(26, 18, state.consider_eval.title(), curses.color_pair(3))
 
     except Exception as e:
         eqa_settings.log(
@@ -1534,6 +1533,24 @@ def draw_settings_options(optscr, configs, state, s_option, s_setting):
         elif state.auto_mob_timer == "false":
             optscr.addstr(17, second_third + 4, "off", curses.color_pair(6))
         optscr.addstr(17, second_third + 7, "]", curses.color_pair(3))
+
+        # Consider
+        if s_option == "consider" and s_setting == "option":
+            optscr.addstr(19, first_q - 1, "Consider Evaluation", curses.color_pair(4))
+            optscr.addstr(
+                2,
+                first_q - 2,
+                "Evaluate mob consider output",
+                curses.color_pair(3),
+            )
+        else:
+            optscr.addstr(19, first_q, "Consider Evaluation", curses.color_pair(1))
+        optscr.addstr(19, second_third, "[", curses.color_pair(3))
+        if state.consider_eval == "true":
+            optscr.addstr(19, second_third + 1, "on", curses.color_pair(5))
+        elif state.consider_eval == "false":
+            optscr.addstr(19, second_third + 4, "off", curses.color_pair(6))
+        optscr.addstr(19, second_third + 7, "]", curses.color_pair(3))
 
     except Exception as e:
         eqa_settings.log(

--- a/eqa/lib/keys.py
+++ b/eqa/lib/keys.py
@@ -276,6 +276,8 @@ def process(
                                 option = "encounter"
                             elif option == "defaulttimer":
                                 option = "saveencounter"
+                            elif option == "consider":
+                                option = "defaulttimer"
                             display_q.put(
                                 eqa_struct.display(
                                     eqa_settings.eqa_time(),
@@ -298,6 +300,8 @@ def process(
                             elif option == "saveencounter":
                                 option = "defaulttimer"
                             elif option == "defaulttimer":
+                                option = "consider"
+                            elif option == "consider":
                                 pass
                             display_q.put(
                                 eqa_struct.display(
@@ -386,6 +390,16 @@ def process(
                                         "false",
                                     )
                                 )
+                            elif option == "consider" and state.consider_eval == "true":
+                                system_q.put(
+                                    eqa_struct.message(
+                                        eqa_settings.eqa_time(),
+                                        "system",
+                                        "consider",
+                                        "eval",
+                                        "false",
+                                    )
+                                )
                         elif key == curses.KEY_LEFT or key == ord("a"):
                             if option == "debug" and state.debug == "false":
                                 system_q.put(
@@ -463,6 +477,18 @@ def process(
                                         "system",
                                         "timer",
                                         "mob",
+                                        "true",
+                                    )
+                                )
+                            elif (
+                                option == "consider" and state.consider_eval == "false"
+                            ):
+                                system_q.put(
+                                    eqa_struct.message(
+                                        eqa_settings.eqa_time(),
+                                        "system",
+                                        "consider",
+                                        "eval",
                                         "true",
                                     )
                                 )

--- a/eqa/lib/parser.py
+++ b/eqa/lib/parser.py
@@ -517,12 +517,14 @@ def check_received_chat(line):
         elif re.fullmatch(r"^\w+ says out of character, \'(.+|)\'$", line) is not None:
             return "ooc"
         elif (
-            re.fullmatch(r"^\w+ auctions, \'(.+|)(WTS|selling|Selling)(.+|)\'$", line)
+            re.fullmatch(
+                r"^\w+ auctions, \'(.+|)(wts|WTS|selling|Selling)(.+|)\'$", line
+            )
             is not None
         ):
             return "auction_wts"
         elif (
-            re.fullmatch(r"^\w+ auctions, \'(.+|)(WTB|buying|Buying)(.+|)\'$", line)
+            re.fullmatch(r"^\w+ auctions, \'(.+|)(wtb|WTB|buying|Buying)(.+|)\'$", line)
             is not None
         ):
             return "auction_wtb"

--- a/eqa/lib/parser.py
+++ b/eqa/lib/parser.py
@@ -1031,10 +1031,10 @@ def check_system_messages(line):
             return "target_attack_too_far"
         elif (
             re.fullmatch(r"^[a-za-z]+ is looking at your equipment\.\.\.$", line)
-            is not none
+            is not None
         ):
             return "inspect_you"
-        elif re.fullmatch(r"^You are inspecting [a-za-z]+\.$", line) is not none:
+        elif re.fullmatch(r"^You are inspecting [a-za-z]+\.$", line) is not None:
             return "inspect_other"
         elif re.fullmatch(r"^You have lost your target\.$", line) is not None:
             return "target_lost"

--- a/eqa/lib/parser.py
+++ b/eqa/lib/parser.py
@@ -293,6 +293,8 @@ def check_melee(line):
             return "mob_slain_other"
         elif re.fullmatch(r"^You have slain [a-zA-Z`\s]+\!$", line) is not None:
             return "mob_slain_you"
+        elif re.fullmatch(r"^You have been slain by [a-zA-Z`\s]+\!$", line) is not None:
+            return "you_slain"
         elif (
             re.fullmatch(r"^Your target is out of range, get closer\!$", line)
             is not None
@@ -309,6 +311,8 @@ def check_melee(line):
             return "experience_group"
         elif re.fullmatch(r"^You have lost experience\.$", line) is not None:
             return "experience_lost"
+        elif re.fullmatch(r"^You have been knocked unconscious\!$", line) is not None:
+            return "unconscious"
         elif re.fullmatch(r"^[a-zA-Z`\s]+ was pierced by thorns\.$", line) is not None:
             return "combat_other_ds_thorns_damage"
         elif re.fullmatch(r"^YOU are pierced by thorns\!$", line) is not None:
@@ -316,6 +320,13 @@ def check_melee(line):
         elif re.fullmatch(r"^[a-zA-Z`\s]+ was burned\.$", line) is not None:
             return "combat_other_ds_fire_damage"
         elif re.fullmatch(r"^YOU are burned\!$", line) is not None:
+            return "combat_you_ds_fire_damage"
+        elif (
+            re.fullmatch(
+                r"^You must first click on the being you wish to attack\!$", line
+            )
+            is not None
+        ):
             return "combat_you_ds_fire_damage"
 
         return None
@@ -339,7 +350,8 @@ def check_spell(line):
         elif re.fullmatch(r"^You begin casting [a-zA-Z\:`\s\']+\.$", line) is not None:
             return "spells_cast_you"
         elif (
-            re.fullmatch(r"^Your [a-zA-Z\s`\:\']+ begins to glow\.$", line) is not None
+            re.fullmatch(r"^Your [0-9a-zA-Z\s`\:\']+ begins to glow\.$", line)
+            is not None
         ):
             return "spells_cast_item_you"
         elif re.fullmatch(r"^\w+\'s spell fizzles\!$", line) is not None:
@@ -404,6 +416,11 @@ def check_spell(line):
             is not None
         ):
             return "spells_scribe_begin"
+        elif (
+            re.fullmatch(r"^You have finished scribing [a-zA-Z`\s\'\:]+\.\.\.$", line)
+            is not None
+        ):
+            return "spells_scribe_finish"
         elif (
             re.fullmatch(
                 r"^Right click on another Scribe Slot in your Spell Book to swap this Spell position with the new one\.$",
@@ -528,11 +545,11 @@ def check_received_chat(line):
             return "say_npc"
         elif re.fullmatch(r"^\w+ shouts, \'(.+|)\'$", line) is not None:
             return "shout"
-        elif re.fullmatch(r"^[a-zA-Z`\s]+ shouts(,|) \'.+\'$", line) is not None:
+        elif re.fullmatch(r"^[a-zA-Z`\s]+( |  )shouts(,|) \'.+\'$", line) is not None:
             return "shout_npc"
         elif re.fullmatch(r"^\w+ tells the guild, \'(.+|)\'$", line) is not None:
             return "guild"
-        elif re.fullmatch(r"^\w+ tells the group, \'.+\'$", line) is not None:
+        elif re.fullmatch(r"^\w+ tells the group, \'(.+|)\'$", line) is not None:
             return "group"
         elif re.fullmatch(r"^\w+ says out of character, \'(.+|)\'$", line) is not None:
             return "ooc"
@@ -570,7 +587,10 @@ def check_sent_chat(line):
     """
 
     try:
-        if re.fullmatch(r"^You told \w+(, \'| \'\[queued\],).+\'$", line) is not None:
+        if (
+            re.fullmatch(r"^You told [a-zA-Z\.]+(, \'| \'\[queued\],).+\'$", line)
+            is not None
+        ):
             return "tell_you"
         elif re.fullmatch(r"^You say, \'.+\'$", line) is not None:
             return "say_you"
@@ -661,8 +681,18 @@ def check_command_output(line):
             return "motd_game"
         elif re.fullmatch(r"^GUILD MOTD\:.+", line) is not None:
             return "motd_guild"
-        elif re.fullmatch(r"^Summoning [a-zA-Z]+\'s corpse\.\.\.", line) is not None:
+        elif re.fullmatch(r"^Summoning [a-zA-Z]+\'s corpse\.\.\.$", line) is not None:
             return "summon_corpse"
+        elif (
+            re.fullmatch(r"^You don\'t have any corpses in this zone\.$", line)
+            is not None
+        ):
+            return "summon_corpse_none"
+        elif (
+            re.fullmatch(r"^You do not have consent to summon that corpse\.$", line)
+            is not None
+        ):
+            return "summon_corpse_no_consent"
         elif (
             re.fullmatch(r"^You can\'t use that command while casting\.\.\.$", line)
             is not None
@@ -703,6 +733,36 @@ def check_command_output(line):
             return "forage_cursor_empty"
         elif re.fullmatch(r"^You must be standing to forage\.$", line) is not None:
             return "forage_standing"
+        elif (
+            re.fullmatch(r"^Hiding all existing corpses except yours\.$", line)
+            is not None
+        ):
+            return "hide_corpse_all"
+        elif re.fullmatch(r"^You have been added to the list\.$", line) is not None:
+            return "list_added"
+        elif (
+            re.fullmatch(
+                r"^You have moved out of the range of the Item List\. If you do not return within 900 seconds, you will be removed from the list\.$",
+                line,
+            )
+            is not None
+        ):
+            return "list_leaving"
+        elif (
+            re.fullmatch(r"^There are no lists in this zone to join\.$", line)
+            is not None
+        ):
+            return "list_none"
+        elif (
+            re.fullmatch(r"^You are already on a list\. You are position \d+\.$", line)
+            is not None
+        ):
+            return "list_position"
+        elif (
+            re.fullmatch(r"^You are not in range of a list to join\.$", line)
+            is not None
+        ):
+            return "list_out_of_range"
 
         return None
 
@@ -727,6 +787,8 @@ def check_system_messages(line):
             return "zoning"
         elif re.fullmatch(r"^You are out of food\.$", line) is not None:
             return "you_outfood"
+        elif re.fullmatch(r"^Ahhh\. That was refreshing\.$", line) is not None:
+            return "drink_you_finish"
         elif re.fullmatch(r"^You are out of drink\.$", line) is not None:
             return "you_outdrink"
         elif re.fullmatch(r"^You are out of food and drink\.$", line) is not None:
@@ -749,6 +811,14 @@ def check_system_messages(line):
             is not None
         ):
             return "drink_other"
+        elif (
+            re.fullmatch(
+                r"^You take a drink from [a-zA-Z\s\:\']+\.$",
+                line,
+            )
+            is not None
+        ):
+            return "drink_you"
         elif (
             re.fullmatch(
                 r"^Chomp, chomp, chomp\.\.\.  [a-zA-Z]+ takes a bite from [a-zA-Z\s\:\']+\.$",
@@ -818,6 +888,8 @@ def check_system_messages(line):
             return "tracking_player_off"
         elif re.fullmatch(r"^Track players \* ON \*$", line) is not None:
             return "tracking_player_on"
+        elif re.fullmatch(r"^You have lost your tracking target\.$", line) is not None:
+            return "tracking_target_lost"
         elif (
             re.fullmatch(
                 r"^The Gods of Norrath emit a sinister laugh as they toy with their creations\. They are reanimating creatures to provide a greater challenge to the mortals$",
@@ -831,7 +903,7 @@ def check_system_messages(line):
             is not None
         ):
             return "earthquake"
-        elif re.fullmatch(r"^[Zone]", line) is not None:
+        elif re.fullmatch(r"^\[Zone\] .+", line) is not None:
             return "zone_message"
         elif re.fullmatch(r"^\<\[SERVER MESSAGE\]\>\:.+", line) is not None:
             return "server_message"
@@ -866,6 +938,8 @@ def check_system_messages(line):
             return "hide_drop"
         elif re.fullmatch(r"^You begin to hide\.\.\.$", line) is not None:
             return "hide_enabled"
+        elif re.fullmatch(r"^You stop hiding\.$", line) is not None:
+            return "hide_disabled"
         elif re.fullmatch(r"^[a-zA-Z\s`]+ was injured by falling\.$", line) is not None:
             return "fall_damage_other"
         elif re.fullmatch(r"^YOU were injured by falling\.$", line) is not None:
@@ -895,6 +969,34 @@ def check_system_messages(line):
             is not None
         ):
             return "target_attack_too_far"
+        elif (
+            re.fullmatch(r"^[a-zA-Z]+ is looking at your equipment\.\.\.$", line)
+            is not None
+        ):
+            return "inspect_you"
+        elif re.fullmatch(r"^You have lost your target\.$", line) is not None:
+            return "target_lost"
+        elif (
+            re.fullmatch(
+                r"^You must wait a bit longer before using the rewind command again\.$",
+                line,
+            )
+            is not None
+        ):
+            return "rewind_output"
+        elif (
+            re.fullmatch(
+                r"^Inventory full, and item is NO TRADE, so cannot auto-inventory the item\.$",
+                line,
+            )
+            is not None
+        ):
+            return "auto_inventory_full"
+        elif (
+            re.fullmatch(r"^I don\'t see anyone by that name around here\.\.\.$", line)
+            is not None
+        ):
+            return "target_cannot_see"
 
         return None
 
@@ -973,6 +1075,21 @@ def check_group_system_messages(line):
             is not None
         ):
             return "group_join_notify"
+        elif re.fullmatch(r"^\w+ is already in another group\.$", line) is not None:
+            return "group_already"
+        elif (
+            re.fullmatch(
+                r"^You must target a player or use \/invite \<name\> to invite someone to your group\.$",
+                line,
+            )
+            is not None
+        ):
+            return "invite_no_target"
+        elif (
+            re.fullmatch(r"^[a-zA-Z]+ is now a regular member of your guild\.$", line)
+            is not None
+        ):
+            return "guild_new_member"
 
         return None
 
@@ -992,12 +1109,12 @@ def check_loot_trade(line):
 
     try:
         if (
-            re.fullmatch(r"^\-\-\w+ has looted [a-zA-Z`\s\:\']+\.\-\-$", line)
+            re.fullmatch(r"^\-\-\w+ has looted [a-zA-Z`\s\:\'\.]+\.\-\-$", line)
             is not None
         ):
             return "looted_item_other"
         elif (
-            re.fullmatch(r"^\-\-You have looted [a-zA-Z`\s\:\']+\.\-\-$", line)
+            re.fullmatch(r"^\-\-You have looted [a-zA-Z`\s\:\'\.]+\.\-\-$", line)
             is not None
         ):
             return "looted_item_you"
@@ -1038,6 +1155,11 @@ def check_loot_trade(line):
             return "trade_npc_payment"
         elif re.fullmatch(r"^You have cancelled the trade\.$", line) is not None:
             return "trade_cancel_you"
+        elif (
+            re.fullmatch(r"^You may not loot this corpse at this time\.$", line)
+            is not None
+        ):
+            return "loot_wait"
 
         return None
 
@@ -9219,6 +9341,8 @@ def check_emotes(line):
             is not None
         ):
             return "emote_laugh_you"
+        elif re.fullmatch(r"^[a-zA-Z]+ laughs at [a-zA-Z`\s]+\.$", line) is not None:
+            return "emote_laugh_other"
         elif (
             re.fullmatch(
                 r"^(You look completely lost\!|You inform [a-zA-Z`\s]+ that you are completely lost\!)$",
@@ -9249,6 +9373,11 @@ def check_emotes(line):
             return "emote_mourn_you"
         elif re.fullmatch(r"^(You nod\.|You nod at [a-zA-Z`\s]+\.)$", line) is not None:
             return "emote_nod_you"
+        elif (
+            re.fullmatch(r"^([a-zA-Z]+ nods\.|[a-zA-Z]+ nods at [a-zA-Z`\s]+\.)$", line)
+            is not None
+        ):
+            return "emote_nod_other"
         elif re.fullmatch(r"^(You nudge|You nudge [a-zA-Z`\s]+\.)$", line) is not None:
             return "emote_nudge_you"
         elif (
@@ -9360,6 +9489,14 @@ def check_emotes(line):
             return "emote_salute_you"
         elif (
             re.fullmatch(
+                r"^[a-zA-Z]+ snaps to attention and salutes [a-zA-Z`\s]+ crisply\.$",
+                line,
+            )
+            is not None
+        ):
+            return "emote_salute_other"
+        elif (
+            re.fullmatch(
                 r"^(You shiver\. Brrrrrr\.|You shiver at the thought of messing with [a-zA-Z`\s]+\.)$",
                 line,
             )
@@ -9450,7 +9587,10 @@ def check_emotes(line):
             is not None
         ):
             return "emote_thank_you"
-        elif re.fullmatch(r"^\w+ thanks [a-zA-Z`\s]+ heartily\.$", line) is not None:
+        elif (
+            re.fullmatch(r"^[a-zA-Z]+ thanks ([a-zA-Z`\s]+ heartily|everyone)\.$", line)
+            is not None
+        ):
             return "emote_thank_other"
         elif (
             re.fullmatch(

--- a/eqa/lib/parser.py
+++ b/eqa/lib/parser.py
@@ -328,6 +328,10 @@ def check_melee(line):
             is not None
         ):
             return "combat_you_ds_fire_damage"
+        elif (
+            re.fullmatch(r"^You can\'t see your target from here\.$", line) is not None
+        ):
+            return "combat_you_cannot_see"
 
         return None
 
@@ -890,6 +894,8 @@ def check_system_messages(line):
             return "tracking_player_on"
         elif re.fullmatch(r"^You have lost your tracking target\.$", line) is not None:
             return "tracking_target_lost"
+        elif re.fullmatch(r"^You begin tracking [a-zA-Z\s`]+$", line) is not None:
+            return "tracking_begin"
         elif (
             re.fullmatch(
                 r"^The Gods of Norrath emit a sinister laugh as they toy with their creations\. They are reanimating creatures to provide a greater challenge to the mortals$",
@@ -932,7 +938,10 @@ def check_system_messages(line):
         ):
             return "autofollow_advice"
         elif (
-            re.fullmatch(r"^You have moved and are no longer hidden\!\!$", line)
+            re.fullmatch(
+                r"^You (?:have moved and are no longer hidden\!\!|are no longer hidden\.)$",
+                line,
+            )
             is not None
         ):
             return "hide_drop"
@@ -1058,6 +1067,13 @@ def check_group_system_messages(line):
             is not None
         ):
             return "group_invite_instruction"
+        elif (
+            re.fullmatch(
+                r"^You cancel the invitation to join [a-zA-Z]+\'s group\.$", line
+            )
+            is not None
+        ):
+            return "group_invite_you_cancel"
         elif re.fullmatch(r"^Your group has been disbanded\.$", line) is not None:
             return "group_disbanded"
         elif (
@@ -1176,6 +1192,11 @@ def check_loot_trade(line):
             is not None
         ):
             return "loot_wait"
+        elif (
+            re.fullmatch(r"^You are too far away to loot that corpse\.$", line)
+            is not None
+        ):
+            return "loot_too_far"
 
         return None
 

--- a/eqa/lib/parser.py
+++ b/eqa/lib/parser.py
@@ -384,16 +384,36 @@ def check_spell(line):
             return "spells_resist_you"
         elif (
             re.fullmatch(
-                r"^.+ w(?:ere|as) hit by non-melee for \d+ ?(points of) damage\.$", line
+                r"^[a-zA-Z`\s]+ was hit by non\-melee for \d+ points of damage\.$", line
             )
             is not None
         ):
-            return "spells_damage"
+            return "spells_damage_other"
+        elif (
+            re.fullmatch(r"^You were hit by non\-melee for \d+ damage\.$", line)
+            is not None
+        ):
+            return "spells_damage_you"
         elif (
             re.fullmatch(r"^Beginning to memorize [a-zA-Z`\s\'\:]+\.\.\.$", line)
             is not None
         ):
             return "spells_memorize_begin"
+        elif (
+            re.fullmatch(r"^Beginning to scribe [a-zA-Z`\s\'\:]+\.\.\.$", line)
+            is not None
+        ):
+            return "spells_scribe_begin"
+        elif (
+            re.fullmatch(
+                r"^Right click on another Scribe Slot in your Spell Book to swap this Spell position with the new one\.$",
+                line,
+            )
+            is not None
+        ):
+            return "spells_scribe_swap_instruction"
+        elif re.fullmatch(r"^Swapping Spell Book Scribe slots\.$", line) is not None:
+            return "spells_scribe_swap"
         elif (
             re.fullmatch(r"^You have finished memorizing [a-zA-Z`\s\'\:]+\.$", line)
             is not None
@@ -674,6 +694,15 @@ def check_command_output(line):
             is not None
         ):
             return "titanium_client_help_message"
+        elif (
+            re.fullmatch(r"^Reading UI data from [a-zA-Z\\]+ directory.\.\.$", line)
+            is not None
+        ):
+            return "client_ui_load"
+        elif re.fullmatch(r"^Forage Error\: Cursor not empty\.$", line) is not None:
+            return "forage_cursor_empty"
+        elif re.fullmatch(r"^You must be standing to forage\.$", line) is not None:
+            return "forage_standing"
 
         return None
 
@@ -861,6 +890,11 @@ def check_system_messages(line):
             is not None
         ):
             return "drag_permission_received"
+        elif (
+            re.fullmatch(r"^Your target is too far away, get closer\!$", line)
+            is not None
+        ):
+            return "target_attack_too_far"
 
         return None
 
@@ -8949,6 +8983,14 @@ def check_emotes(line):
             return "emote_bye_you"
         elif (
             re.fullmatch(
+                r"^[a-zA-Z]+ waves goodbye to [a-zA-Z`\s]+\.$",
+                line,
+            )
+            is not None
+        ):
+            return "emote_bye_other"
+        elif (
+            re.fullmatch(
                 r"^(You cackle gleefully\.|You cackle gleefully at [a-zA-Z`\s]+\.)$",
                 line,
             )
@@ -9425,11 +9467,16 @@ def check_emotes(line):
             is not None
         ):
             return "emote_veto_you"
+        elif re.fullmatch(r"^\w+ vetoes [a-zA-Z`\s]+\'s idea\!$", line) is not None:
+            return "emote_veto_other"
         elif (
             re.fullmatch(r"^(You wave\.|You wave at [a-zA-Z`\s]+\.)$", line) is not None
         ):
             return "emote_wave_you"
-        elif re.fullmatch(r"^\w+ waves at [a-zA-Z`\s]+\.$", line) is not None:
+        elif (
+            re.fullmatch(r"^(\w+ waves at [a-zA-Z`\s]+\.|\w+ waves\.)$", line)
+            is not None
+        ):
             return "emote_wave_other"
         elif (
             re.fullmatch(

--- a/eqa/lib/parser.py
+++ b/eqa/lib/parser.py
@@ -1022,6 +1022,14 @@ def check_system_messages(line):
             is not None
         ):
             return "yell_help"
+        elif (
+            re.fullmatch(
+                r"^[a-zA-Z\s`]+ (?:scowls at you, ready to attack|(?:looks (?:your way apprehensive|upon you warm)|regards you (?:indifferent|as an al)|judges you amiab)ly|gl(?:ares at you threatening|owers at you dubious)ly|kindly considers you) \-\- .+",
+                line,
+            )
+            is not None
+        ):
+            return "consider"
 
         return None
 

--- a/eqa/lib/parser.py
+++ b/eqa/lib/parser.py
@@ -530,6 +530,8 @@ def check_received_chat(line):
             return "auction_wtb"
         elif re.fullmatch(r"^\w+ auctions, \'(.+|)\'$", line) is not None:
             return "auction"
+        elif re.fullmatch(r"^[a-zA-Z]+ BROADCASTS, \'(.+|)\'$", line) is not None:
+            return "broadcast"
 
         return None
 
@@ -656,6 +658,22 @@ def check_command_output(line):
             is not None
         ):
             return "command_invalid"
+        elif (
+            re.fullmatch(
+                r"^You have no friends, but you can add some with\: \/friends \<name\>$",
+                line,
+            )
+            is not None
+        ):
+            return "empty_friends"
+        elif (
+            re.fullmatch(
+                r"^If you need help, click on the EQ Menu button at the bottom of your screen and select the \"Help\" option\.$",
+                line,
+            )
+            is not None
+        ):
+            return "titanium_client_help_message"
 
         return None
 
@@ -696,7 +714,7 @@ def check_system_messages(line):
             return "you_thirsty"
         elif (
             re.fullmatch(
-                r"^Glug, glug, glug\.\.\.  [a-zA-Z]+ takes a drink from [a-zA-Z\s]+\.$",
+                r"^Glug, glug, glug\.\.\.  [a-zA-Z]+ takes a drink from [a-zA-Z\s\:\']+\.$",
                 line,
             )
             is not None
@@ -704,7 +722,7 @@ def check_system_messages(line):
             return "drink_other"
         elif (
             re.fullmatch(
-                r"^Chomp, chomp, chomp\.\.\.  [a-zA-Z]+ takes a bite from [a-zA-Z\s]+\.$",
+                r"^Chomp, chomp, chomp\.\.\.  [a-zA-Z]+ takes a bite from [a-zA-Z\s\:\']+\.$",
                 line,
             )
             is not None
@@ -819,10 +837,30 @@ def check_system_messages(line):
             return "hide_drop"
         elif re.fullmatch(r"^You begin to hide\.\.\.$", line) is not None:
             return "hide_enabled"
-        elif re.fullmatch(r"^[a-zA-Z\s]+ was injured by falling\.$", line) is not None:
+        elif re.fullmatch(r"^[a-zA-Z\s`]+ was injured by falling\.$", line) is not None:
             return "fall_damage_other"
         elif re.fullmatch(r"^YOU were injured by falling\.$", line) is not None:
             return "fall_damage_you"
+        elif (
+            re.fullmatch(r"^[a-zA-Z\s`]+ goes into a berserker frenzy\!$", line)
+            is not None
+        ):
+            return "warrior_berserk_on"
+        elif re.fullmatch(r"^[a-zA-Z\s`]+ is no longer berserk\.$", line) is not None:
+            return "warrior_berserk_off"
+        elif (
+            re.fullmatch(r"^Returning to home point, please wait\.\.\.$", line)
+            is not None
+        ):
+            return "walk_of_shame"
+        elif (
+            re.fullmatch(
+                r"^You have been given permission to drag [a-zA-Z]+\'s corpse in all zones\.$",
+                line,
+            )
+            is not None
+        ):
+            return "drag_permission_received"
 
         return None
 
@@ -2795,6 +2833,11 @@ def check_spell_specific(line):
                 return "spell_song_of_dawn_you_cast"
             elif re.fullmatch(r"^You are no longer terrified\.$", line) is not None:
                 return "spell_song_of_midnight_you_off"
+            elif (
+                re.fullmatch(r"^You feel the ground scream and heave\.$", line)
+                is not None
+            ):
+                return "spell_upheaval_you_on"
             elif re.fullmatch(r"^You hear the music of twilight\.$", line) is not None:
                 return "spell_song_of_twilight_you_on"
             elif re.fullmatch(r"^You play the music of twilight\.$", line) is not None:
@@ -3181,6 +3224,10 @@ def check_spell_specific(line):
                 # return "spell_wonderous_rapidity_you_off"
             elif re.fullmatch(r"^Your enchantments fade\.$", line) is not None:
                 return "spell_abolish_enchantment_you_on"
+            elif re.fullmatch(r"^Your knees buckle\.$", line) is not None:
+                return "spell_avatar_snare_you_on"
+            elif re.fullmatch(r"^Your legs regain strength\.$", line) is not None:
+                return "spell_avatar_snare_you_off"
             elif re.fullmatch(r"^Your eyes tingle\.$", line) is not None:
                 return "spell_line_see_invis_you_on"
                 # return "spell_acumen_you_on"
@@ -4874,13 +4921,6 @@ def check_spell_specific(line):
                 return "spell_trepidation_you_off"
             elif re.fullmatch(r"^The words soften\.$", line) is not None:
                 return "spell_turning_of_the_unnatural_you_off"
-            elif (
-                re.fullmatch(
-                    r"^The ground buckles and heaves beneath your feet\.$", line
-                )
-                is not None
-            ):
-                return "spell_upheaval_you_on"
             elif re.fullmatch(r"^The Mordinia fades\.$", line) is not None:
                 return "spell_vexing_mordinia_you_off"
             elif re.fullmatch(r"^The wrath of nature recedes\.$", line) is not None:
@@ -5166,6 +5206,8 @@ def check_spell_specific(line):
 
         if re.fullmatch(r"^An aegis of faith engulfs you\.$", line) is not None:
             return "spell_aegis_you_on"
+        elif re.fullmatch(r"^[a-zA-Z`\s]+ \'s knees buckle\.$", line) is not None:
+            return "spell_avatar_snare_other_on"
         elif (
             re.fullmatch(r"^[a-zA-Z`\s]+ experiences a quickening\.$", line) is not None
         ):
@@ -5498,6 +5540,11 @@ def check_spell_specific(line):
             return "spell_line_mag_ds_other_on"
             # return "spell_barrier_of_combustion_other_on"
             # return "spell_boon_of_immolation_other_on"
+        elif (
+            re.fullmatch(r"^[a-zA-Z`\s]+ is mauled by the moving ground\.$", line)
+            is not None
+        ):
+            return "spell_upheaval_other_on"
         elif (
             re.fullmatch(
                 r"^[a-zA-Z`\s]+ is surrounded by a swirling maelstrom of magical force\.\.$",
@@ -5840,6 +5887,11 @@ def check_spell_specific(line):
             return "spell_burn_other_on"
         elif re.fullmatch(r"^[a-zA-Z`\s]+ is struck by fire\.$", line) is not None:
             return "spell_burning_vengeance_other_on"
+        elif (
+            re.fullmatch(r"^[a-zA-Z`\s]+ creates a mystic portal\.\.$", line)
+            is not None
+        ):
+            return "spell_circle_of_the_combines_other_on"
         elif (
             re.fullmatch(r"^[a-zA-Z`\s]+ creates a mystic portal\.$", line) is not None
         ):
@@ -9050,6 +9102,8 @@ def check_emotes(line):
             is not None
         ):
             return "emote_grin_you"
+        elif re.fullmatch(r"^[a-zA-Z]+ grins evilly\.$", line) is not None:
+            return "emote_grin_other"
         elif (
             re.fullmatch(
                 r"^(You groan\.|You groan at the sight of [a-zA-Z`\s]+\.)$", line
@@ -9084,6 +9138,8 @@ def check_emotes(line):
             is not None
         ):
             return "emote_hug_you"
+        elif re.fullmatch(r"^[a-zA-Z]+ hugs [a-zA-Z`\s]+\.$", line) is not None:
+            return "emote_hug_other"
         elif (
             re.fullmatch(
                 r"^(You introduce yourself\.  Hi there\!|You introduce [a-zA-Z`\s]+\.)$",
@@ -9193,6 +9249,8 @@ def check_emotes(line):
             is not None
         ):
             return "emote_point_you"
+        elif re.fullmatch(r"^[a-zA-Z]+ pokes [a-zA-Z`\s]+\.$", line) is not None:
+            return "emote_poke_other"
         elif (
             re.fullmatch(r"^(You poke yourself\.|You poke [a-zA-Z`\s]+\.)$", line)
             is not None

--- a/eqa/lib/parser.py
+++ b/eqa/lib/parser.py
@@ -983,6 +983,14 @@ def check_system_messages(line):
             )
             is not None
         ):
+            return "rewind_output_wait"
+        elif (
+            re.fullmatch(
+                r"^Rewinding to previous location\.$",
+                line,
+            )
+            is not None
+        ):
             return "rewind_output"
         elif (
             re.fullmatch(
@@ -997,6 +1005,14 @@ def check_system_messages(line):
             is not None
         ):
             return "target_cannot_see"
+        elif (
+            re.fullmatch(
+                r"^[a-zA-Z]+ yells for help from (?:ahead and to the (?:righ|lef)t of you|behind you(?: and to the (?:righ|lef)t)?|off to the left of you|straight ahead of you)$",
+                line,
+            )
+            is not None
+        ):
+            return "yell_help"
 
         return None
 

--- a/eqa/lib/state.py
+++ b/eqa/lib/state.py
@@ -47,6 +47,7 @@ class EQA_State:
         save_parse,
         auto_raid,
         auto_mob_timer,
+        consider_eval,
     ):
         """All States"""
         self.char = char
@@ -70,6 +71,7 @@ class EQA_State:
         self.save_parse = save_parse
         self.auto_raid = auto_raid
         self.auto_mob_timer = auto_mob_timer
+        self.consider_eval = consider_eval
 
     def set_char(self, char):
         """Set Character"""
@@ -154,3 +156,7 @@ class EQA_State:
     def set_auto_mob_timer(self, auto_mob_timer):
         """Toggle Automatic Mob Timers"""
         self.auto_mob_timer = auto_mob_timer
+
+    def set_consider_eval(self, consider_eval):
+        """Toggle Consider Evaluation"""
+        self.consider_eval = consider_eval

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="eqalert",
-    version="3.2.8",
+    version="3.3.0",
     author="Michael Geitz",
     author_email="git@geitz.xyz",
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="eqalert",
-    version="3.2.6",
+    version="3.2.7",
     author="Michael Geitz",
     author_email="git@geitz.xyz",
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="eqalert",
-    version="3.2.7",
+    version="3.2.8",
     author="Michael Geitz",
     author_email="git@geitz.xyz",
     install_requires=[

--- a/util/spells-to-json.py
+++ b/util/spells-to-json.py
@@ -93,6 +93,7 @@ valid_spells = [
     "avalanche",
     "avatar",
     "avatar_power",
+    "avatar_snare",
     "bandoleer_of_luclin",
     "bane_of_nife",
     "banish_summoned",


### PR DESCRIPTION
With most spell text _actually_ matching now, chasing down the few remaining common lines still reporting as undetermined should be easy after a good amount of playtime.

Please report the following output as a comment to this PR to improve enhancements if you run the parser with debug mode enabled:

> Note: debug mode just generally slows down parser performance, I wouldn't suggest enabling it in game situations where quick responses are critical

```
grep undetermined ~/.eqa/log/debug/matched-lines* | sort | uniq
```

![determination](https://user-images.githubusercontent.com/1339169/175795371-219bb73f-87a1-4ff8-acc1-d1c333023ae7.gif)

Resolves #155 
Resolves #160 
Resolves #163
Resolves #164
Resolves #169