### PR TITLE
Upgrade to Python 3.9.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ util/spells_us.json
 MANIFEST
 build/*
 *.pyc
+eqalert.egg-info/*

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ $ pip3 install eqalert
 _or_ install manually from github
 ```sh
 $ git clone git@github.com:mgeitz/eqalert.git
-$ cd eqalert
-$ python3 setup.py install --user
+$ python3 -m pip install -e ./eqalert
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ $ pip3 install eqalert
 _or_ install manually from github
 ```sh
 $ git clone git@github.com:mgeitz/eqalert.git
-$ python3 -m pip install -e ./eqalert
+$ cd eqalert
+$ python3 -m pip install -e .
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from distutils.core import setup
 
 setup(
     name="eqalert",
-    version="3.4.1",
-    author="Michael Geitz",
+    version="3.4.2",
+    author="M Geitz",
     author_email="git@geitz.xyz",
     install_requires=[
         "playsound",
         "gtts",
     ],
-    python_requires=">3",
+    python_requires=">=3.9.2",
     packages=["eqa", "eqa.lib", "eqa.sound"],
     include_package_data=True,
     package_data={"eqa.sound": ["*.wav"]},

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ setup(
     author="M Geitz",
     author_email="git@geitz.xyz",
     install_requires=[
-        "playsound",
-        "gtts",
+        "playsound>=1.3.0",
+        "gtts>=2.3.1",
     ],
     python_requires=">=3.9.2",
     packages=["eqa", "eqa.lib", "eqa.sound"],


### PR DESCRIPTION
![careful](https://user-images.githubusercontent.com/1339169/220207082-5dd6c7ae-7512-4ab7-81da-a89d9d2f0eda.gif)

- Fixed installation command in README.  The old one required a manual uninstall via removing eqalert files from the default pip install paths and wouldn't pull down dependencies from pip if they were needed,  never noticed this until installing on a fresh system.  The assets produced by this installation command can be removed no different than if the package were downloaded from pypi via pip.

- Resolves #175 
- Resolves #176