### PR TITLE
Code coverage report when running all the tests

### DIFF
--- a/eqa/lib/util.py
+++ b/eqa/lib/util.py
@@ -24,7 +24,7 @@ def handleException(e: Exception, e_desc: str, e_print=True, e_log=False):
 
 
 class SerializedFileHandler(ABC):
-    def __init__(self, filename: str | Path) -> None:
+    def __init__(self, filename: Path) -> None:
         self.filename = filename
 
     @abstractmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ eqalert = 'eqa.eqalert:main'
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.pytest.ini_options]
+addopts = "--cov=eqa --cov-report html:coverage/html --cov-report lcov:coverage/coverage.lcov"
+
 [tool.coverage.run]
 omit = [ "__init__.py", ]
 branch = true


### PR DESCRIPTION
Quick little QoL change.  When running `poetry run pytest` also do a code coverage analysis:

```
╰─ poetry run pytest
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.11.1, pytest-8.1.1, pluggy-1.4.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/isaac/repos/eqalert
configfile: pyproject.toml
plugins: benchmark-4.0.0, cov-5.0.0, mock-3.12.0
collected 5 items                                                                                                                                                         

tests/lib/test_config.py .....                                                                                                                                      [100%]/home/isaac/repos/eqalert/.venv/lib/python3.11/site-packages/coverage/report_core.py:115: CoverageWarning: Couldn't parse '/home/isaac/repos/eqalert/eqa/lib/parser.py': maximum recursion depth exceeded in comparison (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")


---------- coverage: platform linux, python 3.11.1-final-0 -----------
Coverage HTML written to dir coverage/html
Coverage LCOV written to file coverage/coverage.lcov


============================================================================ 5 passed in 4.17s ============================================================================
```

I use the LCOV report for a VSCode extension - it will highlight lines as covered/uncovered. This could also be used to upload results to something like Codecov to display a coverage badge or PR messages if desired.

I also set the HTML report as a "nice to have" - you can open `eqalert/coverage/html/index.html` in a browser to view coverage.