### PR TITLE
Refactor New Character Log Config

### DIFF
--- a/eqa/lib/util.py
+++ b/eqa/lib/util.py
@@ -36,12 +36,10 @@ class SerializedFileHandler(ABC):
         pass
 
     def write(self, data):
-        with open(self.filename, "w", encoding="utf-8") as file:
-            file.write(self.serialize(data) or "")
+        self.filename.write_bytes(self.serialize(data) or "")
 
     def read(self) -> dict:
-        with open(self.filename, "r", encoding="utf-8") as file:
-            return self.deserialize(file.read()) or {}
+        return self.deserialize(self.filename.read_text() or {})
 
 
 class JSONFileHandler(SerializedFileHandler):

--- a/eqa/models/config.py
+++ b/eqa/models/config.py
@@ -1,35 +1,38 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Union
 
 from eqa.models.util import BaseFlag, Location
 
 
 @dataclass
 class CharacterState:
-    bind: str | None
-    char_class: str | None
-    direction: str | None
-    encumbered: bool
-    guild: str | None
-    level: int | None
-    location: Location
-    zone: str | None
+    # Python 3.9 syntax
+    # If upgraded to min version Python 3.12 this becomes:
+    # bind: str | None = None
+
+    bind: Union[str, None] = None
+    char_class: Union[str, None] = None
+    direction: Union[str, None] = None
+    encumbered: bool = False
+    guild: Union[str, None] = None
+    level: Union[int, None] = None
+    location: Location = field(default_factory=lambda: Location())
+    zone: Union[str, None] = None
 
 
 @dataclass
 class CharacterLog:
-    char: str
     char_state: CharacterState
     character: str
-    disabled: bool
-    filename: str
+    file_name: str
     server: str
+    disabled: bool = False
 
 
 @dataclass
-class Character:
-    character_logs: Dict[str, CharacterLog] = field(
+class Characters:
+    char_logs: Dict[str, CharacterLog] = field(
         default_factory=lambda: {}, compare=False
     )
 
@@ -52,12 +55,12 @@ class EncounterParsing(BaseFlag):
 
 @dataclass
 class SystemPaths:
-    data: str | Path
-    eqalert_log: str | Path
-    everquest_files: str | Path
-    everquest_logs: str | Path
-    sound: str | Path
-    tmp_sound: str | Path
+    data: Union[str, Path]
+    eqalert_log: Union[str, Path]
+    everquest_files: Union[str, Path]
+    everquest_logs: Union[str, Path]
+    sound: Union[str, Path]
+    tmp_sound: Union[str, Path]
 
 
 @dataclass
@@ -169,7 +172,7 @@ class LineAlertFile:
 
 @dataclass
 class Config:
-    characters: Character
+    characters: Characters
     settings: Setting
     zones: Zones
     line_alerts: Dict[str, LineAlertFile] = field(

--- a/eqa/models/util.py
+++ b/eqa/models/util.py
@@ -4,9 +4,9 @@ from typing import Dict
 
 @dataclass
 class Location:
-    x: float
-    y: float
-    z: float
+    x: str = "0.00"
+    y: str = "0.00"
+    z: str = "0.00"
 
 
 @dataclass


### PR DESCRIPTION
Overview:
Slow, steady, test-backed changes to work toward converting the configs to types objects instead of dictionaries.  This refactor should have no changes to existing functionality.  When creating a new character log it first creates it as a CharacterLog object, then converts it to the old-style dictionary before appending it to the config named tuple in memory.  When the day comes to move the named tuple config to a type-backed data models, we just remove the conversion and append the new object.  :clap: :dash: .  EZPZ

Re: changes to the models... There were a couple of changes I needed to make to the dataclasses in order to make them work and compatible with Python 3.9.  

Changes:
- add_char_log: move writing to disk outside of function & validating into the function
- SerializedFileHandler: use pathlib instead of file.open
- use config Character model
- dataclasses python 3.9 compatibility
- refactor create new characters with new models and convert to legacy config
- Update models to reflect legacy formats
 
![yo](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZGJtN3o2eTl5OXNiZjFhemhlemhoMTMwNTU4cnc2Y2t2eWIzY3ZmZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tYAolvs3tZIhG/giphy.gif)